### PR TITLE
Handle nullable field parsing in `useUrlParams` and adjust `Subscript…

### DIFF
--- a/src/components/Subscriptions/SubscriptionFinder.tsx
+++ b/src/components/Subscriptions/SubscriptionFinder.tsx
@@ -168,7 +168,7 @@ export const SubscriptionFinderPanel: React.FC<Props> = ({
                                           ]}
                                           optionValue={o => o.value}
                                           optionTitle={i => i.label}
-                                          onChange={(val) => onChange({...value, inactive: val === 'Inactive'})}
+                                          onChange={(val) => onChange({...value, inactive: val === undefined ? null : val === 'Inactive'})}
                             />
                         </FormField>
                     }

--- a/src/hooks/useUrlParams.ts
+++ b/src/hooks/useUrlParams.ts
@@ -29,6 +29,18 @@ export const useUrlParams = <T extends Record<string, any>>(
           (params as any)[key] = value === 'true';
         } else if (typeof defaultValue === 'string' || defaultValue === undefined) {
           (params as any)[key] = value;
+        } else if (defaultValue === null) {
+          // For nullable fields, infer primitive value from URL text.
+          if (value === 'true' || value === 'false') {
+            (params as any)[key] = value === 'true';
+          } else {
+            const numValue = Number(value);
+            if (!isNaN(numValue) && value.trim() !== '') {
+              (params as any)[key] = numValue;
+            } else {
+              (params as any)[key] = value;
+            }
+          }
         }
       }
     });


### PR DESCRIPTION
…ionFinder` onChange logic for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Subscription status filter now correctly handles the "All" option selection
  * URL parameters are now properly parsed and converted to appropriate data types (booleans and numbers)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->