### PR TITLE
fix: remove pull_request trigger from CI/CD workflow configuration

### DIFF
--- a/.github/workflows/bitween-ui-cicd.yml
+++ b/.github/workflows/bitween-ui-cicd.yml
@@ -1,10 +1,8 @@
 name: Bitween UI CI/CD
+run-name: Run-${{ github.ref_name }}-${{ github.run_number }}
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
     branches:
       - main
   workflow_dispatch:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD workflow run naming for improved visibility in the GitHub UI.
  * Modified workflow triggers; the workflow no longer automatically runs on pull requests to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->