### PR TITLE
feat: Enhance Mapping Editor with Partner and Global Variable Support

### DIFF
--- a/src/client/apis/mappersApi.ts
+++ b/src/client/apis/mappersApi.ts
@@ -4,6 +4,7 @@ import customFetchBase from 'src/client/apis/apiMiddleware';
 export interface MapperPreviewRequest {
   scribanTemplate: string;
   inputJson: string;
+  partnerId?: number | null;
 }
 
 export interface MapperPreviewResponse {

--- a/src/client/apis/partnersApi.ts
+++ b/src/client/apis/partnersApi.ts
@@ -1,0 +1,45 @@
+import { createApi } from '@reduxjs/toolkit/query/react';
+import customFetchBase from 'src/client/apis/apiMiddleware';
+
+export interface PartnerListItem {
+  id: number;
+  name: string;
+}
+
+export interface PartnerDetail {
+  id?: number;
+  name: string;
+  adapterProperties?: Record<string, string>;
+}
+
+export const PartnersApi = createApi({
+  baseQuery: customFetchBase,
+  reducerPath: 'PartnersApi',
+  tagTypes: ['partners'],
+  endpoints: (builder) => ({
+    partners: builder.query<PartnerListItem[], void>({
+      providesTags: ['partners'],
+      query: () => ({ url: 'partners', method: 'GET' }),
+      transformResponse: (raw: any) => {
+        const arr = raw?.result ?? raw ?? [];
+        return (arr as any[]).map((p: any) => ({ id: Number(p.id), name: p.name }));
+      },
+    }),
+    partner: builder.query<PartnerDetail, number>({
+      providesTags: ['partners'],
+      query: (id) => ({ url: `partners/${id}`, method: 'GET' }),
+      transformResponse: (raw: any) => {
+        // Handle both direct response and wrapped { result: ... }
+        const data = raw?.result ?? raw;
+        const props = data?.adapterProperties ?? data?.AdapterProperties ?? undefined;
+        return {
+          id: data?.id ?? data?.Id,
+          name: data?.name ?? data?.Name ?? '',
+          adapterProperties: props ?? undefined,
+        };
+      },
+    }),
+  }),
+});
+
+export const { usePartnersQuery, usePartnerQuery } = PartnersApi;

--- a/src/components/MappingEditor/ArrayMappingModal.tsx
+++ b/src/components/MappingEditor/ArrayMappingModal.tsx
@@ -11,6 +11,7 @@ import {
 import { ArrayMapping, FilterOperator, LookupDictionary, LookupEntry, genId } from './types';
 import { buildTypeMap } from 'src/utils/scribanGenerator';
 import { getFullSourcePath, getFullTargetBase, getItemArrayPaths, collectArrayPaths, getItemProperties, generateExample } from './arrayMappingHelpers';
+import { useGlobalAdapterValuesSetsQuery } from 'src/client/apis/globalAdapterValuesSetsApi';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -27,7 +28,9 @@ const OPERATORS: { label: string; value: FilterOperator }[] = [
 
 const ArrayMappingModal: React.FC = () => {
   const dispatch = useMappingEditorDispatch();
-  const { editingArrayId, arrayMappings, fieldMappings, inputJson, outputJson, newArrayPresetTarget, newArrayParentId } = useMappingEditorState();
+  const { editingArrayId, arrayMappings, fieldMappings, inputJson, outputJson, newArrayPresetTarget, newArrayParentId, partnerAdapterProperties, selectedPartnerId } = useMappingEditorState();
+  const { data: globalSetsData } = useGlobalAdapterValuesSetsQuery({ offset: 0, limit: 1000 });
+  const allGlobalSets = globalSetsData?.result ?? [];
 
   const am = arrayMappings.find((m) => m.id === editingArrayId);
   const parentAm = newArrayParentId ? arrayMappings.find((m) => m.id === newArrayParentId) : undefined;
@@ -65,6 +68,9 @@ const [pendingMappings, setPendingMappings] = useState<Array<{
     transform?: string; fixedValue?: string;
     lookupDictionary?: LookupDictionary;
     isRootSource?: boolean;
+    partnerPropKey?: string;
+    globalSetId?: string;
+    globalKey?: string;
   }>>([]);
   // Which secondary panel is open for each mapping row: 'transform' | 'lookup' | 'fixed' | null
   const [openPanels, setOpenPanels] = useState<Record<string, 'transform' | 'lookup' | 'fixed' | null>>({});
@@ -417,14 +423,14 @@ const [pendingMappings, setPendingMappings] = useState<Array<{
                   setOpenPanels((prev) => ({ ...prev, [m.id]: isOpen ? null : 'lookup' }));
                 };
 
-                const rowMode = hasFixed ? 'fixed' : 'source';
+                const rowMode = m.partnerPropKey !== undefined ? 'partner' : m.globalSetId !== undefined ? 'global' : hasFixed ? 'fixed' : 'source';
 
                 return (
                   <div key={m.id} className="rounded border border-gray-100 bg-white px-2 py-1.5 space-y-1">
                     {/* Row: target ← [src|≡|"] source-selector [ƒ] [trash] */}
                     <div className="flex items-center gap-1">
                       {/* mapped indicator dot */}
-                      <span className={`w-2 h-2 rounded-full flex-shrink-0 ${m.source || hasFixed ? 'bg-emerald-400' : 'bg-rose-300'}`} />
+                      <span className={`w-2 h-2 rounded-full flex-shrink-0 ${m.source || hasFixed || m.partnerPropKey || (m.globalSetId && m.globalKey) ? 'bg-emerald-400' : 'bg-rose-300'}`} />
 
                       {/* target field — dropdown if known, otherwise free-text */}
                       {targetItemProps.length > 0 ? (
@@ -449,41 +455,64 @@ const [pendingMappings, setPendingMappings] = useState<Array<{
 
                       <span className="text-gray-300 flex-shrink-0 text-xs select-none">←</span>
 
-                      {/* src/fx toggle button — disabled until a target is chosen */}
-                      <button
-                        disabled={!m.target}
-                        title={!m.target ? 'Select a target field first' : rowMode === 'fixed' ? 'Switch to source binding' : 'Switch to fixed value'}
-                        onClick={() => {
-                          if (rowMode === 'fixed') {
-                            setPendingMappings((prev) => prev.map((p) => p.id === m.id ? { ...p, fixedValue: undefined, lookupDictionary: undefined } : p));
-                            setOpenPanels((prev) => ({ ...prev, [m.id]: null }));
-                          } else {
-                            setOpenPanels((prev) => ({ ...prev, [m.id]: null }));
-                            setPendingMappings((prev) => prev.map((p) => p.id === m.id ? { ...p, source: '', fixedValue: '', lookupDictionary: undefined } : p));
-                          }
-                        }}
-                        className={[
-                          'flex-shrink-0 text-[11px] font-mono px-1.5 py-0.5 rounded border transition leading-none',
-                          !m.target ? 'opacity-30 cursor-not-allowed bg-white border-gray-200 text-gray-400'
-                            : rowMode === 'fixed' ? 'bg-amber-50 border-amber-300 text-amber-600'
-                            : 'bg-white border-gray-200 text-gray-400 hover:border-blue-300 hover:text-blue-500',
-                        ].join(' ')}
-                      >{rowMode === 'fixed' ? 'fx' : 'src'}</button>
+                      {/* Source / Fixed / Partner / Global mode toggle */}
+                      <div className={`flex flex-shrink-0 rounded overflow-hidden border text-[10px] font-medium ${!m.target ? 'opacity-30 pointer-events-none border-gray-200' : 'border-gray-200'}`}>
+                        <button
+                          disabled={!m.target}
+                          onClick={() => {
+                            if (rowMode !== 'source') {
+                              setPendingMappings((prev) => prev.map((p) => p.id === m.id ? { ...p, fixedValue: undefined, partnerPropKey: undefined, globalSetId: undefined, globalKey: undefined, lookupDictionary: undefined } : p));
+                              setOpenPanels((prev) => ({ ...prev, [m.id]: null }));
+                            }
+                          }}
+                          className={rowMode === 'source' ? 'px-1.5 py-0.5 bg-blue-500 text-white' : 'px-1.5 py-0.5 text-gray-400 hover:bg-gray-50'}
+                        >Source</button>
+                        <button
+                          disabled={!m.target}
+                          onClick={() => {
+                            if (rowMode !== 'fixed') {
+                              setOpenPanels((prev) => ({ ...prev, [m.id]: null }));
+                              setPendingMappings((prev) => prev.map((p) => p.id === m.id ? { ...p, source: '', fixedValue: '', partnerPropKey: undefined, globalSetId: undefined, globalKey: undefined, lookupDictionary: undefined } : p));
+                            }
+                          }}
+                          className={rowMode === 'fixed' ? 'px-1.5 py-0.5 bg-amber-500 text-white border-l border-amber-400' : 'px-1.5 py-0.5 text-gray-400 border-l border-gray-200 hover:bg-gray-50'}
+                        >Fixed</button>
+                          <button
+                            disabled={!m.target}
+                            onClick={() => {
+                              if (rowMode !== 'partner') {
+                                setOpenPanels((prev) => ({ ...prev, [m.id]: null }));
+                                setPendingMappings((prev) => prev.map((p) => p.id === m.id ? { ...p, source: '', fixedValue: undefined, partnerPropKey: '', globalSetId: undefined, globalKey: undefined, lookupDictionary: undefined, transform: undefined } : p));
+                              }
+                            }}
+                            className={rowMode === 'partner' ? 'px-1.5 py-0.5 bg-emerald-500 text-white border-l border-emerald-400' : 'px-1.5 py-0.5 text-gray-400 border-l border-gray-200 hover:bg-gray-50'}
+                          >Partner</button>
+                        <button
+                          disabled={!m.target}
+                          onClick={() => {
+                            if (rowMode !== 'global') {
+                              setOpenPanels((prev) => ({ ...prev, [m.id]: null }));
+                              setPendingMappings((prev) => prev.map((p) => p.id === m.id ? { ...p, source: '', fixedValue: undefined, partnerPropKey: undefined, globalSetId: '', globalKey: '', lookupDictionary: undefined, transform: undefined } : p));
+                            }
+                          }}
+                          className={rowMode === 'global' ? 'px-1.5 py-0.5 bg-teal-500 text-white border-l border-teal-400' : 'px-1.5 py-0.5 text-gray-400 border-l border-gray-200 hover:bg-gray-50'}
+                        >Global</button>
+                      </div>
 
-                      {/* ≡ lookup dictionary button — requires source */}
-                      <button
+                      {/* Lookup button — only in source mode */}
+                      {rowMode === 'source' && <button
                         disabled={!m.source}
-                        title={!m.source ? 'Select a source field first' : hasLookup ? `Lookup: ${m.lookupDictionary!.entries.length} entries` : 'Add value lookup dictionary'}
+                        title={!m.source ? 'Select a source field first' : hasLookup ? `Lookup: ${m.lookupDictionary!.entries.length} entries` : 'Map source values to different output values'}
                         onClick={openLookup}
                         className={[
-                          'flex-shrink-0 text-[11px] font-mono px-1.5 py-0.5 rounded border transition leading-none',
+                          'flex-shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded border transition leading-none',
                           !m.source ? 'opacity-30 cursor-not-allowed bg-white border-gray-200 text-gray-400'
                             : hasLookup ? 'bg-violet-100 border-violet-300 text-violet-700'
                             : 'bg-white border-gray-200 text-gray-400 hover:border-violet-300 hover:text-violet-500',
                         ].join(' ')}
-                      >≡</button>
+                      >Lookup</button>}
 
-                      {/* source selector or fixed value input */}
+                      {/* source selector, fixed input, partner input, or global pickers */}
                       {rowMode === 'fixed' ? (
                         <input
                           className="flex-1 min-w-0 border-0 bg-transparent font-mono text-xs text-amber-600 focus:outline-none placeholder-amber-300"
@@ -491,6 +520,46 @@ const [pendingMappings, setPendingMappings] = useState<Array<{
                           value={m.fixedValue ?? ''}
                           onChange={(e) => setPendingMappings((prev) => prev.map((p) => p.id === m.id ? { ...p, fixedValue: e.target.value, source: '' } : p))}
                         />
+                      ) : rowMode === 'partner' ? (
+                        <div className="flex-1 relative min-w-0">
+                          <input
+                            list={`partner-props-am-${m.id}`}
+                            className="w-full border-0 bg-transparent font-mono text-xs focus:outline-none text-emerald-600 placeholder-emerald-300"
+                            placeholder="property key…"
+                            value={m.partnerPropKey ?? ''}
+                            onChange={(e) => setPendingMappings((prev) => prev.map((p) => p.id === m.id ? { ...p, partnerPropKey: e.target.value } : p))}
+                          />
+                          <datalist id={`partner-props-am-${m.id}`}>
+                            {Object.keys(partnerAdapterProperties).map((k) => (
+                              <option key={k} value={k} />
+                            ))}
+                          </datalist>
+                        </div>
+                      ) : rowMode === 'global' ? (
+                        <div className="flex gap-1 flex-1 min-w-0">
+                          <select
+                            className="border-0 bg-transparent font-mono text-xs focus:outline-none text-teal-600 flex-1 min-w-0"
+                            value={m.globalSetId ?? ''}
+                            onChange={(e) => setPendingMappings((prev) => prev.map((p) => p.id === m.id ? { ...p, globalSetId: e.target.value, globalKey: '' } : p))}
+                          >
+                            <option value="">— pick set —</option>
+                            {allGlobalSets.map((s) => (
+                              <option key={s.id} value={s.id}>{s.name}</option>
+                            ))}
+                          </select>
+                          {m.globalSetId && (
+                            <select
+                              className="border-0 bg-transparent font-mono text-xs focus:outline-none text-teal-500 flex-1 min-w-0"
+                              value={m.globalKey ?? ''}
+                              onChange={(e) => setPendingMappings((prev) => prev.map((p) => p.id === m.id ? { ...p, globalKey: e.target.value } : p))}
+                            >
+                              <option value="">— pick key —</option>
+                              {Object.keys(allGlobalSets.find((s) => s.id === m.globalSetId)?.values ?? {}).map((k) => (
+                                <option key={k} value={k}>{k}</option>
+                              ))}
+                            </select>
+                          )}
+                        </div>
                       ) : (
                         <select
                           disabled={!m.target}
@@ -526,19 +595,19 @@ const [pendingMappings, setPendingMappings] = useState<Array<{
                         </select>
                       )}
 
-                      {/* ƒ transform toggle — only when source selected and no lookup active */}
+                      {/* Transform toggle — only in source mode with a source selected and no lookup */}
                       {rowMode === 'source' && Boolean(m.source) && !hasLookup && <button
-                        title={hasTransform ? `Expression: ${m.transform}` : 'Add expression transform'}
+                        title={hasTransform ? `Transform: ${m.transform}` : 'Add a transform expression to modify the value'}
                         onClick={openTransform}
                         className={[
-                          'flex-shrink-0 text-[11px] font-mono px-1.5 py-0.5 rounded border transition leading-none',
+                          'flex-shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded border transition leading-none',
                           panel === 'transform'
                             ? 'bg-violet-100 border-violet-300 text-violet-700'
                             : hasTransform
-                            ? 'bg-violet-50 border-violet-200 text-violet-400'
+                            ? 'bg-violet-50 border-violet-200 text-violet-500'
                             : 'bg-white border-gray-200 text-gray-400 hover:border-violet-300 hover:text-violet-500',
                         ].join(' ')}
-                      >ƒ</button>}
+                      >Transform</button>}
 
                       {/* delete */}
                       <button
@@ -554,12 +623,12 @@ const [pendingMappings, setPendingMappings] = useState<Array<{
 
                     {/* Secondary row — only when panel is open */}
                     {panel === 'transform' && (
-                      <div className="flex items-center gap-1.5">
-                        <span className="text-[10px] text-violet-400 font-mono flex-shrink-0 w-4 text-center select-none">ƒ</span>
+                      <div className="space-y-0.5">
+                        <span className="text-[10px] font-medium text-violet-600 select-none">Transform <span className="font-normal text-gray-400">(optional — modify the value before output. Use <code className="font-mono">value</code> to refer to the source field.)</span></span>
                         <input
                           autoFocus
-                          className="flex-1 border border-violet-200 bg-white rounded px-2 py-0.5 text-xs font-mono focus:outline-none focus:border-violet-400 placeholder-gray-300 text-violet-700"
-                          placeholder="e.g. value * 1.1  — 'value' = source field"
+                          className="w-full border border-violet-200 bg-white rounded px-2 py-1 text-xs font-mono focus:outline-none focus:border-violet-400 placeholder-gray-300 text-violet-700"
+                          placeholder="e.g.  value * 1.1    or    value + ' USD'"
                           value={m.transform ?? ''}
                           onChange={(e) => {
                             setPendingMappings((prev) => prev.map((p) => p.id === m.id ? { ...p, transform: e.target.value || undefined } : p));
@@ -801,7 +870,7 @@ const [pendingMappings, setPendingMappings] = useState<Array<{
                 !target ||
                 (hasFilter && !source) ||
                 pendingMappings.some(
-                  (m) => m.target && !m.source && m.fixedValue === undefined && !m.lookupDictionary
+                  (m) => m.target && !m.source && m.fixedValue === undefined && !m.lookupDictionary && !m.partnerPropKey && !(m.globalSetId && m.globalKey)
                 )
               }
               className="text-xs bg-blue-600 text-white rounded px-4 py-1.5 hover:bg-blue-700 transition disabled:opacity-40 disabled:cursor-not-allowed"

--- a/src/components/MappingEditor/FixedItemPanel.tsx
+++ b/src/components/MappingEditor/FixedItemPanel.tsx
@@ -1,10 +1,13 @@
 import React, { useState } from 'react';
-import { HiOutlinePencil, HiOutlineTrash } from 'react-icons/hi';
+import { HiOutlinePencil, HiOutlinePlusCircle, HiOutlineTrash } from 'react-icons/hi';
 import { TreeNode } from 'src/utils/mappingPreview';
+import { LookupDictionary, LookupEntry } from './types';
+import { useGlobalAdapterValuesSetsQuery } from 'src/client/apis/globalAdapterValuesSetsApi';
+import { useMappingEditorState } from './MappingEditorContext';
 
 // ─── Fixed-item inline panel types ───────────────────────────────────────────
 
-export type DraftFieldMode = 'source' | 'fixed' | 'array';
+export type DraftFieldMode = 'source' | 'fixed' | 'array' | 'partner' | 'global';
 
 export interface DraftField {
   key: string;
@@ -12,6 +15,13 @@ export interface DraftField {
   value: string;
   transform: string;
   showTransform: boolean;
+  // partner mode:
+  partnerPropKey?: string;
+  // global mode:
+  globalSetId?: string;
+  globalKey?: string;
+  // source lookup dictionary:
+  lookupDictionary?: LookupDictionary;
   // array mode only:
   nestedChildNode?: TreeNode;
   nestedItems?: DraftField[][];
@@ -30,6 +40,14 @@ export function initDraftFieldsFromNode(node: TreeNode | undefined): DraftField[
   return [{ key: '', mode: 'fixed' as DraftFieldMode, value: '', transform: '', showTransform: false }];
 }
 
+function parseLookupEntries(dictStr: string): LookupEntry[] {
+  const entries: LookupEntry[] = [];
+  const re = /"([^"]+)": "([^"]*)"/g;
+  let m;
+  while ((m = re.exec(dictStr)) !== null) entries.push({ from: m[1], to: m[2] });
+  return entries;
+}
+
 export function draftFieldsToRecord(fields: DraftField[]): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (const df of fields) {
@@ -37,11 +55,32 @@ export function draftFieldsToRecord(fields: DraftField[]): Record<string, unknow
     if (!k) continue;
     if (df.mode === 'array') {
       result[k] = (df.nestedItems ?? []).map((itemFields) => draftFieldsToRecord(itemFields));
+    } else if (df.mode === 'partner') {
+      if (!df.partnerPropKey?.trim()) continue;
+      result[k] = `{{__partner__?.${df.partnerPropKey.trim()}}}`;
+    } else if (df.mode === 'global') {
+      if (!df.globalSetId?.trim() || !df.globalKey?.trim()) continue;
+      result[k] = `{{__globals__?.${df.globalSetId.trim()}["${df.globalKey.trim()}"]}}` ;
     } else if (df.mode === 'source') {
       if (!df.value.trim()) continue;
+      const src = df.value.trim();
+      const lkp = df.lookupDictionary;
+      if (lkp?.entries?.length) {
+        const valid = lkp.entries.filter(({ from, to }) => from.trim() !== '' && to.trim() !== '');
+        if (valid.length > 0) {
+          const entriesStr = valid.map(({ from, to }) => `"${from}": "${to}"`).join(', ');
+          if (lkp.fallback === 'null') {
+            result[k] = `{{$__e = { ${entriesStr} }; $__e[${src}]}}`;
+          } else {
+            const fb = lkp.fallback === 'custom' ? `"${lkp.fallbackValue ?? ''}"` : src;
+            result[k] = `{{$__e = { ${entriesStr} }; ($__e[${src}] ?? ${fb})}}`;
+          }
+          continue;
+        }
+      }
       const expr = df.transform.trim()
-        ? df.transform.trim().replace(/\bvalue\b/g, df.value.trim())
-        : df.value.trim();
+        ? df.transform.trim().replace(/\bvalue\b/g, src)
+        : src;
       result[k] = `{{${expr}}}`;
     } else {
       if (df.value.trim() === '') continue;
@@ -79,7 +118,31 @@ export function recordToDraftFields(item: Record<string, unknown>, node: TreeNod
     }
     if (typeof v === 'string') {
       const m = v.match(/^\{\{(.+)\}\}$/);
-      if (m) return { key, mode: 'source', value: m[1].trim(), transform: '', showTransform: false };
+      if (m) {
+        const expr = m[1].trim();
+        // Partner: {{__partner__?.propkey}}
+        const partnerMatch = expr.match(/^__partner__\??\.([\w]+)$/);
+        if (partnerMatch) return { key, mode: 'partner', value: '', transform: '', showTransform: false, partnerPropKey: partnerMatch[1] };
+        // Global: {{__globals__?.setid["key"]}}
+        const globalMatch = expr.match(/^__globals__\??\.([\w]+)\["([^"]+)"\]$/);
+        if (globalMatch) return { key, mode: 'global', value: '', transform: '', showTransform: false, globalSetId: globalMatch[1], globalKey: globalMatch[2] };
+        // Lookup (null fallback): $__e = { ... }; $__e[path]
+        const lkpNull = expr.match(/^\$__e = \{ (.+) \}; \$__e\[(.+)\]$/);
+        if (lkpNull) return { key, mode: 'source', value: lkpNull[2], transform: '', showTransform: false, lookupDictionary: { entries: parseLookupEntries(lkpNull[1]), fallback: 'null' } };
+        // Lookup (passthrough/custom): $__e = { ... }; ($__e[path] ?? FB)
+        const lkpFb = expr.match(/^\$__e = \{ (.+) \}; \(\$__e\[(.+)\] \?\? (.+)\)$/);
+        if (lkpFb) {
+          const path = lkpFb[2];
+          const fbStr = lkpFb[3];
+          const isPassthrough = fbStr === path;
+          return { key, mode: 'source', value: path, transform: '', showTransform: false, lookupDictionary: {
+            entries: parseLookupEntries(lkpFb[1]),
+            fallback: isPassthrough ? 'passthrough' : 'custom',
+            fallbackValue: isPassthrough ? undefined : fbStr.replace(/^"(.*)"$/, '$1'),
+          }};
+        }
+        return { key, mode: 'source', value: expr, transform: '', showTransform: false };
+      }
     }
     return { key, mode: 'fixed', value: v !== undefined ? String(v) : '', transform: '', showTransform: false };
   });
@@ -99,6 +162,11 @@ export interface FixedItemFieldRowsProps {
 export const FixedItemFieldRows: React.FC<FixedItemFieldRowsProps> = ({
   fields, onFieldsChange, parentNode, depth, inputScalarProps, idPrefix,
 }) => {
+  const { partnerAdapterProperties, selectedPartnerId } = useMappingEditorState();
+  const { data: globalSetsData } = useGlobalAdapterValuesSetsQuery({ offset: 0, limit: 1000 });
+  const allGlobalSets = globalSetsData?.result ?? [];
+  const [lookupOpenIdx, setLookupOpenIdx] = useState<number | null>(null);
+
   const hasFreeKey = parentNode.children.filter((c) => c.type === 'leaf').length === 0;
   const childArrayNodes = parentNode.children.filter((c) => c.type === 'array');
   const usedArrayKeys = new Set(fields.filter((f) => f.mode === 'array').map((f) => f.key));
@@ -169,7 +237,10 @@ export const FixedItemFieldRows: React.FC<FixedItemFieldRowsProps> = ({
                           <div key={fi} className="flex items-center gap-1 text-[9px] font-mono">
                             <span className="text-indigo-700 flex-shrink-0">{f.key}:</span>
                             <span className="text-gray-500 truncate">
-                              {f.mode === 'source' ? (f.transform ? `fx(${f.value})` : f.value) : (f.value || '—')}
+                              {f.mode === 'source' ? (f.transform ? `fx(${f.value})` : f.value)
+                                : f.mode === 'partner' ? `__partner__.${f.partnerPropKey ?? ''}`
+                                : f.mode === 'global' ? `__globals__.${f.globalSetId ?? ''}["${f.globalKey ?? ''}"]`
+                                : (f.value || '—')}
                             </span>
                           </div>
                         ) : (
@@ -214,52 +285,209 @@ export const FixedItemFieldRows: React.FC<FixedItemFieldRowsProps> = ({
             </div>
           );
         }
-        // leaf field (source / fixed)
+        // leaf field (fixed / source / partner / global)
+        const hasLookup = (df.lookupDictionary?.entries?.length ?? 0) > 0;
+        const isLookupOpen = lookupOpenIdx === i;
         return (
           <div key={`${df.key}-leaf-${i}`} className="space-y-0.5">
-            <div className="flex items-center gap-1">
+            <div className="flex items-center gap-1.5">
               {hasFreeKey ? (
-                <input className="w-20 border border-teal-200 bg-white rounded px-1.5 py-0.5 text-xs font-mono focus:outline-none focus:border-teal-400"
+                <input
+                  className="w-20 flex-shrink-0 border border-gray-200 bg-transparent rounded px-1.5 py-0.5 text-xs font-mono focus:outline-none focus:border-blue-400"
                   placeholder="key" value={df.key}
                   onChange={(e) => updateField(i, { key: e.target.value })} />
               ) : (
-                <span className="w-20 flex-shrink-0 font-mono text-teal-800 text-xs truncate">{df.key}</span>
+                <span className="w-20 flex-shrink-0 font-mono text-gray-700 text-xs truncate">{df.key}</span>
               )}
-              <div className="flex rounded overflow-hidden border border-teal-200 flex-shrink-0">
-                {(['fixed', 'source'] as DraftFieldMode[]).map((m) => (
-                  <button key={m}
-                    className={`px-1.5 py-0.5 text-[10px] transition ${df.mode === m ? 'bg-teal-500 text-white' : 'bg-white text-teal-600 hover:bg-teal-50'}`}
-                    onClick={() => updateField(i, { mode: m })}>{m}</button>
-                ))}
+              <span className="text-gray-300 flex-shrink-0">←</span>
+
+              {/* Mode buttons — same style as OutputLeaf */}
+              <div className="flex flex-shrink-0 rounded overflow-hidden border border-gray-200 text-[10px] font-medium">
+                <button
+                  onClick={() => updateField(i, { mode: 'source', partnerPropKey: undefined, globalSetId: undefined, globalKey: undefined })}
+                  className={df.mode === 'source' ? 'px-1.5 py-0.5 bg-blue-500 text-white' : 'px-1.5 py-0.5 text-gray-400 hover:bg-gray-50'}
+                >Source</button>
+                <button
+                  onClick={() => { updateField(i, { mode: 'fixed', value: '', partnerPropKey: undefined, globalSetId: undefined, globalKey: undefined, lookupDictionary: undefined }); setLookupOpenIdx(null); }}
+                  className={df.mode === 'fixed' ? 'px-1.5 py-0.5 bg-amber-500 text-white' : 'px-1.5 py-0.5 text-gray-400 border-l border-gray-200 hover:bg-gray-50'}
+                >Fixed</button>
+                <button
+                  onClick={() => { updateField(i, { mode: 'partner', value: '', transform: '', globalSetId: undefined, globalKey: undefined, lookupDictionary: undefined }); setLookupOpenIdx(null); }}
+                  className={df.mode === 'partner' ? 'px-1.5 py-0.5 bg-emerald-500 text-white border-l border-emerald-400' : 'px-1.5 py-0.5 text-gray-400 border-l border-gray-200 hover:bg-gray-50'}
+                >Partner</button>
+                <button
+                  onClick={() => { updateField(i, { mode: 'global', value: '', transform: '', partnerPropKey: undefined, lookupDictionary: undefined }); setLookupOpenIdx(null); }}
+                  className={df.mode === 'global' ? 'px-1.5 py-0.5 bg-teal-500 text-white border-l border-teal-400' : 'px-1.5 py-0.5 text-gray-400 border-l border-gray-200 hover:bg-gray-50'}
+                >Global</button>
               </div>
-              {df.mode === 'source' ? (
-                <>
-                  <input list={`${idPrefix}-s-${i}`}
-                    className="flex-1 min-w-0 border border-teal-200 bg-white rounded px-1.5 py-0.5 text-xs font-mono focus:outline-none focus:border-teal-400"
-                    placeholder="source.field" value={df.value}
-                    onChange={(e) => updateField(i, { value: e.target.value })} />
-                  {inputScalarProps.length > 0 && (
-                    <datalist id={`${idPrefix}-s-${i}`}>
-                      {inputScalarProps.map((p) => <option key={p} value={p} />)}
-                    </datalist>
-                  )}
-                </>
-              ) : (
-                <input className="flex-1 min-w-0 border border-teal-200 bg-white rounded px-1.5 py-0.5 text-xs font-mono focus:outline-none focus:border-teal-400"
-                  placeholder="literal value" value={df.value}
-                  onChange={(e) => updateField(i, { value: e.target.value })} />
-              )}
+
+              {/* Lookup button — only in source mode, matches OutputLeaf styling */}
               {df.mode === 'source' && (
                 <button
-                  className={`flex-shrink-0 px-1.5 py-0.5 rounded border text-[10px] transition ${df.showTransform ? 'bg-amber-400 text-white border-amber-400' : 'bg-white text-amber-600 border-amber-200 hover:bg-amber-50'}`}
-                  onClick={() => updateField(i, { showTransform: !df.showTransform })}
-                  title="Apply formula (use 'value' to refer to the source field)">fx</button>
+                  onClick={() => {
+                    if (isLookupOpen && !hasLookup) {
+                      updateField(i, { lookupDictionary: undefined });
+                    }
+                    setLookupOpenIdx(isLookupOpen ? null : i);
+                  }}
+                  title={hasLookup ? `Lookup: ${df.lookupDictionary!.entries.length} entries` : 'Map source values to different output values'}
+                  className={[
+                    'flex-shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded border transition',
+                    hasLookup || isLookupOpen
+                      ? 'border-violet-400 bg-violet-50 text-violet-600'
+                      : 'border-gray-200 text-gray-400 hover:border-violet-300 hover:text-violet-500',
+                  ].join(' ')}
+                >Lookup</button>
+              )}
+
+              {/* Value area */}
+              {df.mode === 'source' && (
+                <select
+                  className="flex-1 border-0 bg-transparent font-mono text-xs focus:outline-none text-gray-500 min-w-0"
+                  value={df.value}
+                  onChange={(e) => updateField(i, { value: e.target.value })}>
+                  <option value="">— unassigned —</option>
+                  {inputScalarProps.map((p) => <option key={p} value={p}>{p}</option>)}
+                </select>
+              )}
+              {df.mode === 'fixed' && (
+                <input
+                  className="flex-1 border-0 bg-transparent font-mono text-xs focus:outline-none text-amber-600 min-w-0 placeholder-amber-300"
+                  placeholder="fixed value…"
+                  value={df.value}
+                  onChange={(e) => updateField(i, { value: e.target.value })} />
+              )}
+              {df.mode === 'partner' && (
+                <>
+                  <input
+                    list={`${idPrefix}-partner-${i}`}
+                    className="flex-1 border-0 bg-transparent font-mono text-xs focus:outline-none text-emerald-600 min-w-0 placeholder-emerald-300"
+                    placeholder="property key…"
+                    value={df.partnerPropKey ?? ''}
+                    onChange={(e) => updateField(i, { partnerPropKey: e.target.value })} />
+                  <datalist id={`${idPrefix}-partner-${i}`}>
+                    {Object.keys(partnerAdapterProperties).map((p) => <option key={p} value={p} />)}
+                  </datalist>
+                </>
+              )}
+              {df.mode === 'global' && (
+                <div className="flex gap-1 flex-1 min-w-0">
+                  <select
+                    className="border-0 bg-transparent font-mono text-xs focus:outline-none text-teal-600 flex-1 min-w-0"
+                    value={df.globalSetId ?? ''}
+                    onChange={(e) => updateField(i, { globalSetId: e.target.value, globalKey: undefined })}>
+                    <option value="">— pick set —</option>
+                    {allGlobalSets.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}
+                  </select>
+                  {df.globalSetId && (
+                    <select
+                      className="border-0 bg-transparent font-mono text-xs focus:outline-none text-teal-500 flex-1 min-w-0"
+                      value={df.globalKey ?? ''}
+                      onChange={(e) => updateField(i, { globalKey: e.target.value })}>
+                      <option value="">— pick key —</option>
+                      {Object.keys(allGlobalSets.find((s) => s.id === df.globalSetId)?.values ?? {}).map((vk) =>
+                        <option key={vk} value={vk}>{vk}</option>
+                      )}
+                    </select>
+                  )}
+                </div>
+              )}
+
+              {/* Delete row — only for free-key fields */}
+              {hasFreeKey && (
+                <button
+                  className="flex-shrink-0 text-gray-300 hover:text-rose-500 transition"
+                  onClick={() => { onFieldsChange(fields.filter((_, j) => j !== i)); if (lookupOpenIdx === i) setLookupOpenIdx(null); }}>
+                  <HiOutlineTrash size={12} />
+                </button>
               )}
             </div>
-            {df.mode === 'source' && df.showTransform && (
-              <input className="w-full border border-amber-200 bg-white rounded px-1.5 py-0.5 text-xs font-mono focus:outline-none focus:border-amber-400"
-                placeholder="e.g. value * 1.2" value={df.transform}
-                onChange={(e) => updateField(i, { transform: e.target.value })} />
+
+            {/* Lookup dictionary panel — matches OutputLeaf exactly */}
+            {df.mode === 'source' && isLookupOpen && (
+              <div className="px-2 pb-2 pt-0.5">
+                <div className="rounded-lg border border-violet-200 bg-violet-50 p-2 space-y-1.5">
+                  {/* Entry rows */}
+                  <div className="space-y-1 max-h-40 overflow-y-auto">
+                    {(df.lookupDictionary?.entries ?? []).length === 0 && (
+                      <p className="text-[10px] text-violet-400 italic px-1">No entries yet.</p>
+                    )}
+                    {(df.lookupDictionary?.entries ?? []).map((entry: LookupEntry, idx: number) => (
+                      <div key={idx} className="flex items-center gap-1">
+                        <input
+                          autoFocus={idx === 0}
+                          className="flex-1 min-w-0 border border-violet-200 bg-white rounded px-2 py-0.5 text-xs font-mono focus:outline-none focus:border-violet-400 placeholder-gray-300"
+                          placeholder="source value"
+                          value={entry.from}
+                          onChange={(e) => {
+                            const val = e.target.value;
+                            const lkp = df.lookupDictionary!;
+                            updateField(i, { lookupDictionary: { ...lkp, entries: lkp.entries.map((ee, ei) => ei === idx ? { ...ee, from: val } : ee) } });
+                          }}
+                        />
+                        <span className="text-gray-300 text-[10px] flex-shrink-0 select-none">→</span>
+                        <input
+                          className="flex-1 min-w-0 border border-violet-200 bg-white rounded px-2 py-0.5 text-xs font-mono focus:outline-none focus:border-violet-400 placeholder-gray-300"
+                          placeholder="output value"
+                          value={entry.to}
+                          onChange={(e) => {
+                            const val = e.target.value;
+                            const lkp = df.lookupDictionary!;
+                            updateField(i, { lookupDictionary: { ...lkp, entries: lkp.entries.map((ee, ei) => ei === idx ? { ...ee, to: val } : ee) } });
+                          }}
+                        />
+                        <button
+                          className="flex-shrink-0 text-gray-300 hover:text-rose-400 transition"
+                          onClick={() => {
+                            const lkp = df.lookupDictionary!;
+                            updateField(i, { lookupDictionary: { ...lkp, entries: lkp.entries.filter((_, ei) => ei !== idx) } });
+                          }}
+                        >
+                          <HiOutlineTrash size={11} />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                  {/* Add entry */}
+                  <button
+                    className="flex items-center gap-1 text-[10px] text-violet-500 hover:text-violet-700 transition font-medium"
+                    onClick={() => {
+                      const existing = df.lookupDictionary ?? { entries: [], fallback: 'passthrough' as const };
+                      updateField(i, { lookupDictionary: { ...existing, entries: [...existing.entries, { from: '', to: '' }] } });
+                    }}
+                  >
+                    <HiOutlinePlusCircle size={11} /> Add entry
+                  </button>
+                  {/* Fallback — only when at least one entry */}
+                  {(df.lookupDictionary?.entries?.length ?? 0) > 0 && (
+                    <div className="flex items-center gap-2 pt-1 border-t border-violet-200">
+                      <span className="text-[10px] text-gray-500 flex-shrink-0 select-none">If not found:</span>
+                      <select
+                        className="text-xs border border-violet-200 bg-white rounded px-1.5 py-0.5 font-mono focus:outline-none focus:border-violet-400 text-violet-700"
+                        value={df.lookupDictionary?.fallback ?? 'passthrough'}
+                        onChange={(e) => updateField(i, { lookupDictionary: { ...df.lookupDictionary!, fallback: e.target.value as LookupDictionary['fallback'] } })}
+                      >
+                        <option value="passthrough">keep original value</option>
+                        <option value="null">output null</option>
+                        <option value="custom">use custom fallback</option>
+                      </select>
+                      {df.lookupDictionary?.fallback === 'custom' && (
+                        <input
+                          className="flex-1 min-w-0 border border-violet-200 bg-white rounded px-2 py-0.5 text-xs font-mono focus:outline-none focus:border-violet-400 placeholder-gray-300 text-violet-700"
+                          placeholder="fallback value"
+                          value={df.lookupDictionary.fallbackValue ?? ''}
+                          onChange={(e) => updateField(i, { lookupDictionary: { ...df.lookupDictionary!, fallbackValue: e.target.value } })}
+                        />
+                      )}
+                    </div>
+                  )}
+                  {/* Remove lookup */}
+                  <button
+                    className="text-[10px] text-rose-400 hover:text-rose-600 transition"
+                    onClick={() => { updateField(i, { lookupDictionary: undefined }); setLookupOpenIdx(null); }}
+                  >Remove lookup</button>
+                </div>
+              </div>
             )}
           </div>
         );

--- a/src/components/MappingEditor/LivePreview.tsx
+++ b/src/components/MappingEditor/LivePreview.tsx
@@ -8,7 +8,7 @@ import { useValuesSetMap } from 'src/hooks/useValuesSetMap';
 const DEBOUNCE_MS = 600;
 
 const LivePreview: React.FC = () => {
-  const { inputJson, outputJson: targetSchemaJson, fieldMappings, arrayMappings, manualTemplate, mode, validationErrors } = useMappingEditorState();
+  const { inputJson, outputJson: targetSchemaJson, fieldMappings, arrayMappings, manualTemplate, mode, validationErrors, partnerAdapterProperties, selectedPartnerId } = useMappingEditorState();
 
   const valuesSetMap = useValuesSetMap();
   const [previewMapping] = usePreviewMappingMutation();
@@ -21,7 +21,11 @@ const LivePreview: React.FC = () => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
 
     debounceRef.current = setTimeout(async () => {
-      if (!inputJson.trim()) {
+      const hasPartnerProps = Object.keys(partnerAdapterProperties).length > 0;
+      // If no source JSON but partner props exist, use {} as base so __partner__ can still be injected
+      const effectiveInputJson = !inputJson.trim() && hasPartnerProps ? '{}' : inputJson;
+
+      if (!effectiveInputJson.trim() && !selectedPartnerId) {
         setOutputJson(null);
         setPreviewError(null);
         return;
@@ -31,12 +35,13 @@ const LivePreview: React.FC = () => {
       const template =
         mode === 'manual' && manualTemplate
           ? manualTemplate
-          : generateScriban(fieldMappings, arrayMappings, valuesSetMap, targetSchemaJson || undefined, inputJson || undefined);
+          : generateScriban(fieldMappings, arrayMappings, valuesSetMap, targetSchemaJson || undefined, effectiveInputJson || undefined);
 
       try {
         const result = await previewMapping({
           scribanTemplate: template,
-          inputJson,
+          inputJson: effectiveInputJson || '{}',
+          partnerId: selectedPartnerId,
         }).unwrap();
         setOutputJson(result.outputJson ?? null);
         setPreviewError(result.error ?? null);
@@ -49,7 +54,7 @@ const LivePreview: React.FC = () => {
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [inputJson, fieldMappings, arrayMappings, manualTemplate, mode, valuesSetMap]);
+  }, [inputJson, fieldMappings, arrayMappings, manualTemplate, mode, valuesSetMap, partnerAdapterProperties, selectedPartnerId]);
 
   const formatted = outputJson !== null ? outputJson : null;
 

--- a/src/components/MappingEditor/MappingEditorToolbar.tsx
+++ b/src/components/MappingEditor/MappingEditorToolbar.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   HiArrowLeft,
@@ -13,7 +13,9 @@ import {
   clearAll,
   redo,
   undo,
+  setSelectedPartner,
 } from './MappingEditorContext';
+import { usePartnersQuery, usePartnerQuery } from 'src/client/apis/partnersApi';
 
 // ─── Mode toggle button ───────────────────────────────────────────────────────
 
@@ -58,7 +60,34 @@ const MappingEditorToolbar: React.FC<MappingEditorToolbarProps> = ({
 }) => {
   const navigate = useNavigate();
   const dispatch = useMappingEditorDispatch();
-  const { mode, fieldMappings, arrayMappings, past, future } = useMappingEditorState();
+  const { mode, fieldMappings, arrayMappings, past, future, selectedPartnerId } = useMappingEditorState();
+  const [localPartnerId, setLocalPartnerId] = useState<number | null>(selectedPartnerId);
+
+  // Sync local dropdown state when Redux restores a saved PartnerId on load
+  React.useEffect(() => {
+    if (selectedPartnerId != null && localPartnerId !== selectedPartnerId) {
+      setLocalPartnerId(selectedPartnerId);
+    }
+  }, [selectedPartnerId]);
+  const { data: partners } = usePartnersQuery();
+  const { data: partnerDetail, isFetching: isPartnerFetching } = usePartnerQuery(localPartnerId!, { skip: localPartnerId == null });
+
+  const handlePartnerChange = (idStr: string) => {
+    const pid = idStr ? Number(idStr) : null;
+    setLocalPartnerId(pid);
+    if (pid == null) {
+      dispatch(setSelectedPartner(null, {}));
+    }
+    // partnerDetail effect below handles dispatch when data arrives
+  };
+
+  React.useEffect(() => {
+    if (localPartnerId == null) return;
+    // Wait until RTK Query has finished fetching for the current localPartnerId.
+    // While isFetching is true, `data` may still be the previous partner's cached response.
+    if (isPartnerFetching) return;
+    dispatch(setSelectedPartner(localPartnerId, partnerDetail?.adapterProperties ?? {}));
+  }, [partnerDetail, localPartnerId, isPartnerFetching]);
 
   const assignedFieldCount = useMemo(
     () => fieldMappings.filter((m) => m.target && (Boolean(m.source) || m.fixedValue !== undefined)).length,
@@ -157,6 +186,28 @@ const MappingEditorToolbar: React.FC<MappingEditorToolbarProps> = ({
       >
         Validate
       </button>
+
+      {/* Partner selector — visual mode only — for testing partner-scoped mappings */}
+      {isVisualMode && (
+        <div className="flex items-center gap-1.5">
+          <span className="text-[10px] text-gray-400 font-medium uppercase tracking-wide flex-shrink-0">Test partner</span>
+          <select
+            className="text-xs border border-gray-200 rounded px-2 py-1 focus:outline-none focus:border-blue-400 bg-white text-gray-700 max-w-[160px]"
+            value={localPartnerId ?? ''}
+            onChange={(e) => handlePartnerChange(e.target.value)}
+          >
+            <option value="">— none —</option>
+            {(partners ?? []).map((p) => (
+              <option key={p.id} value={p.id}>{p.name}</option>
+            ))}
+          </select>
+          {localPartnerId && (
+            <span className="text-[10px] text-emerald-600 font-medium flex-shrink-0">
+              {Object.keys(partnerDetail?.adapterProperties ?? {}).length} props
+            </span>
+          )}
+        </div>
+      )}
 
       <div className="ml-auto flex items-center gap-2">
         {saveSuccess && (

--- a/src/components/MappingEditor/MappingEditorToolbar.tsx
+++ b/src/components/MappingEditor/MappingEditorToolbar.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   HiArrowLeft,
@@ -61,33 +61,26 @@ const MappingEditorToolbar: React.FC<MappingEditorToolbarProps> = ({
   const navigate = useNavigate();
   const dispatch = useMappingEditorDispatch();
   const { mode, fieldMappings, arrayMappings, past, future, selectedPartnerId } = useMappingEditorState();
-  const [localPartnerId, setLocalPartnerId] = useState<number | null>(selectedPartnerId);
 
-  // Sync local dropdown state when Redux restores a saved PartnerId on load
-  React.useEffect(() => {
-    if (selectedPartnerId != null && localPartnerId !== selectedPartnerId) {
-      setLocalPartnerId(selectedPartnerId);
-    }
-  }, [selectedPartnerId]);
+  // Sync local dropdown state when Redux selectedPartnerId changes (including reset to null)
   const { data: partners } = usePartnersQuery();
-  const { data: partnerDetail, isFetching: isPartnerFetching } = usePartnerQuery(localPartnerId!, { skip: localPartnerId == null });
+  const { data: partnerDetail, isFetching: isPartnerFetching } = usePartnerQuery(selectedPartnerId ?? 0, { skip: selectedPartnerId == null });
 
   const handlePartnerChange = (idStr: string) => {
     const pid = idStr ? Number(idStr) : null;
-    setLocalPartnerId(pid);
     if (pid == null) {
       dispatch(setSelectedPartner(null, {}));
+    } else {
+      dispatch(setSelectedPartner(pid, {}));
     }
     // partnerDetail effect below handles dispatch when data arrives
   };
 
   React.useEffect(() => {
-    if (localPartnerId == null) return;
-    // Wait until RTK Query has finished fetching for the current localPartnerId.
-    // While isFetching is true, `data` may still be the previous partner's cached response.
+    if (selectedPartnerId == null) return;
     if (isPartnerFetching) return;
-    dispatch(setSelectedPartner(localPartnerId, partnerDetail?.adapterProperties ?? {}));
-  }, [partnerDetail, localPartnerId, isPartnerFetching]);
+    dispatch(setSelectedPartner(selectedPartnerId, partnerDetail?.adapterProperties ?? {}));
+  }, [partnerDetail, selectedPartnerId, isPartnerFetching]);
 
   const assignedFieldCount = useMemo(
     () => fieldMappings.filter((m) => m.target && (Boolean(m.source) || m.fixedValue !== undefined)).length,
@@ -193,7 +186,7 @@ const MappingEditorToolbar: React.FC<MappingEditorToolbarProps> = ({
           <span className="text-[10px] text-gray-400 font-medium uppercase tracking-wide flex-shrink-0">Test partner</span>
           <select
             className="text-xs border border-gray-200 rounded px-2 py-1 focus:outline-none focus:border-blue-400 bg-white text-gray-700 max-w-[160px]"
-            value={localPartnerId ?? ''}
+            value={selectedPartnerId ?? ''}
             onChange={(e) => handlePartnerChange(e.target.value)}
           >
             <option value="">— none —</option>
@@ -201,7 +194,7 @@ const MappingEditorToolbar: React.FC<MappingEditorToolbarProps> = ({
               <option key={p.id} value={p.id}>{p.name}</option>
             ))}
           </select>
-          {localPartnerId && (
+          {selectedPartnerId && (
             <span className="text-[10px] text-emerald-600 font-medium flex-shrink-0">
               {Object.keys(partnerDetail?.adapterProperties ?? {}).length} props
             </span>

--- a/src/components/MappingEditor/OutputLeaf.tsx
+++ b/src/components/MappingEditor/OutputLeaf.tsx
@@ -11,6 +11,7 @@ import {
   updateFieldMapping,
 } from './MappingEditorContext';
 import { getFullTargetPrefix } from './mappingTreeUtils';
+import { useGlobalAdapterValuesSetsQuery } from 'src/client/apis/globalAdapterValuesSetsApi';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -40,8 +41,10 @@ function getValueAtPath(obj: unknown, path: string): string {
 
 export const OutputLeaf: React.FC<OutputLeafProps> = ({ node, sourcePaths, typeMap, onLeafRef, isSearchMatch }) => {
   const dispatch = useMappingEditorDispatch();
-  const { fieldMappings, arrayMappings, selectedMappingId: selectedId, outputJson } = useMappingEditorState();
+  const { fieldMappings, arrayMappings, selectedMappingId: selectedId, outputJson, partnerAdapterProperties } = useMappingEditorState();
   const [lookupOpen, setLookupOpen] = useState(false);
+  const { data: globalSetsData } = useGlobalAdapterValuesSetsQuery({ offset: 0, limit: 1000 });
+  const allGlobalSets = globalSetsData?.result ?? [];
 
   // Type of this target field, derived from the typeMap passed from the tree root
   const targetFieldType = typeMap[node.path]
@@ -65,13 +68,14 @@ export const OutputLeaf: React.FC<OutputLeafProps> = ({ node, sourcePaths, typeM
   // ── Normal field mapping lookup ───────────────────────────────────────────
   const mapping = !isArrayField ? fieldMappings.find((m) => m.target === node.path) : undefined;
   const isMapped = isArrayField
-    ? Boolean(innerMapping?.source || innerMapping?.fixedValue !== undefined)
+    ? Boolean(innerMapping?.source || innerMapping?.fixedValue !== undefined || innerMapping?.partnerPropKey || (innerMapping?.globalSetId && innerMapping?.globalKey))
     : Boolean(mapping?.source || mapping?.fixedValue !== undefined ||
-        (mapping?.lookupDictionary?.entries?.length ?? 0) > 0 || mapping?.valuesSetId);
+        (mapping?.lookupDictionary?.entries?.length ?? 0) > 0 || mapping?.valuesSetId || mapping?.partnerPropKey ||
+        (mapping?.globalSetId && mapping?.globalKey));
   const isSelected = mapping ? selectedId === mapping.id : false;
 
-  // Derived mode: 'fixed' | 'source'
-  const currentMode = mapping?.fixedValue !== undefined ? 'fixed' : 'source';
+  // Derived mode: 'fixed' | 'source' | 'partner' | 'global'
+  const currentMode = mapping?.partnerPropKey !== undefined ? 'partner' : mapping?.globalSetId !== undefined ? 'global' : mapping?.fixedValue !== undefined ? 'fixed' : 'source';
   const hasLookup = (mapping?.lookupDictionary?.entries?.length ?? 0) > 0;
 
   const ref = useCallback(
@@ -98,7 +102,7 @@ export const OutputLeaf: React.FC<OutputLeafProps> = ({ node, sourcePaths, typeM
     }
   };
 
-  const switchMode = (e: React.MouseEvent, next: 'source' | 'fixed') => {
+  const switchMode = (e: React.MouseEvent, next: 'source' | 'fixed' | 'partner' | 'global') => {
     if (isArrayField) return;
     e.stopPropagation();
     if (next === 'fixed') {
@@ -110,7 +114,21 @@ export const OutputLeaf: React.FC<OutputLeafProps> = ({ node, sourcePaths, typeM
       if (!mapping) {
         dispatch(addFieldMapping({ source: '', target: node.path, fixedValue: sampleValue }));
       } else {
-        dispatch(updateFieldMapping({ id: mapping.id, source: '', fixedValue: sampleValue, valuesSetId: undefined, lookupDictionary: undefined, transform: undefined }));
+        dispatch(updateFieldMapping({ id: mapping.id, source: '', fixedValue: sampleValue, partnerPropKey: undefined, globalSetId: undefined, globalKey: undefined, valuesSetId: undefined, lookupDictionary: undefined, transform: undefined }));
+      }
+      setLookupOpen(false);
+    } else if (next === 'partner') {
+      if (!mapping) {
+        dispatch(addFieldMapping({ source: '', target: node.path, partnerPropKey: '' }));
+      } else {
+        dispatch(updateFieldMapping({ id: mapping.id, source: '', fixedValue: undefined, partnerPropKey: '', globalSetId: undefined, globalKey: undefined, valuesSetId: undefined, lookupDictionary: undefined, transform: undefined }));
+      }
+      setLookupOpen(false);
+    } else if (next === 'global') {
+      if (!mapping) {
+        dispatch(addFieldMapping({ source: '', target: node.path, globalSetId: '', globalKey: '' }));
+      } else {
+        dispatch(updateFieldMapping({ id: mapping.id, source: '', fixedValue: undefined, partnerPropKey: undefined, globalSetId: '', globalKey: '', valuesSetId: undefined, lookupDictionary: undefined, transform: undefined }));
       }
       setLookupOpen(false);
     } else {
@@ -118,7 +136,7 @@ export const OutputLeaf: React.FC<OutputLeafProps> = ({ node, sourcePaths, typeM
       if (!mapping) {
         dispatch(addFieldMapping({ source: '', target: node.path }));
       } else {
-        dispatch(updateFieldMapping({ id: mapping.id, fixedValue: undefined, valuesSetId: undefined }));
+        dispatch(updateFieldMapping({ id: mapping.id, fixedValue: undefined, partnerPropKey: undefined, globalSetId: undefined, globalKey: undefined, valuesSetId: undefined }));
       }
     }
   };
@@ -141,6 +159,10 @@ export const OutputLeaf: React.FC<OutputLeafProps> = ({ node, sourcePaths, typeM
       ? innerMapping.source
       : innerMapping?.fixedValue !== undefined
       ? `"${innerMapping.fixedValue}"`
+      : innerMapping?.partnerPropKey
+      ? `__partner__.${innerMapping.partnerPropKey}`
+      : innerMapping?.globalSetId && innerMapping?.globalKey
+      ? `__globals__.${innerMapping.globalSetId}["${innerMapping.globalKey}"]`
       : null;
 
     return (
@@ -197,27 +219,31 @@ export const OutputLeaf: React.FC<OutputLeafProps> = ({ node, sourcePaths, typeM
         <span className="font-mono text-gray-700 truncate">{node.key}</span>
         <span className="text-gray-300 mx-0.5 flex-shrink-0">←</span>
 
-        {/* Mode buttons: src/fx toggle + ≡ lookup */}
-        <button
-          onClick={(e) => switchMode(e, currentMode === 'source' ? 'fixed' : 'source')}
-          title={currentMode === 'fixed' ? 'Switch to source binding' : 'Switch to fixed value'}
-          className={[
-            'flex-shrink-0 text-xs font-mono px-1 rounded border transition',
-            currentMode === 'fixed'
-              ? 'border-amber-300 bg-amber-50 text-amber-600'
-              : 'border-gray-200 text-gray-400 hover:border-blue-300 hover:text-blue-500',
-          ].join(' ')}
-        >
-          {currentMode === 'fixed' ? 'fx' : 'src'}
-        </button>
-        {/* ≡ lookup button — only in source mode */}
+        {/* Mode buttons: Source / Fixed / Partner / Global */}
+        <div className="flex flex-shrink-0 rounded overflow-hidden border border-gray-200 text-[10px] font-medium">
+          <button
+            onClick={(e) => switchMode(e, 'source')}
+            className={currentMode === 'source' ? 'px-1.5 py-0.5 bg-blue-500 text-white' : 'px-1.5 py-0.5 text-gray-400 hover:bg-gray-50'}
+          >Source</button>
+          <button
+            onClick={(e) => switchMode(e, 'fixed')}
+            className={currentMode === 'fixed' ? 'px-1.5 py-0.5 bg-amber-500 text-white' : 'px-1.5 py-0.5 text-gray-400 border-l border-gray-200 hover:bg-gray-50'}
+          >Fixed</button>
+          <button
+              onClick={(e) => { e.stopPropagation(); switchMode(e, 'partner'); }}
+              className={currentMode === 'partner' ? 'px-1.5 py-0.5 bg-emerald-500 text-white border-l border-emerald-400' : 'px-1.5 py-0.5 text-gray-400 border-l border-gray-200 hover:bg-gray-50'}
+            >Partner</button>
+          <button
+            onClick={(e) => { e.stopPropagation(); switchMode(e, 'global'); }}
+            className={currentMode === 'global' ? 'px-1.5 py-0.5 bg-teal-500 text-white border-l border-teal-400' : 'px-1.5 py-0.5 text-gray-400 border-l border-gray-200 hover:bg-gray-50'}
+          >Global</button>
+        </div>
         {currentMode === 'source' && (
           <button
             onClick={(e) => {
               e.stopPropagation();
               setLookupOpen((v) => {
                 if (v && mapping) {
-                  // closing — clear dict if no valid entries (both from and to filled)
                   const entries = mapping.lookupDictionary?.entries ?? [];
                   const hasValid = entries.some(e => e.from.trim() !== '' && e.to.trim() !== '');
                   if (!hasValid) {
@@ -227,14 +253,14 @@ export const OutputLeaf: React.FC<OutputLeafProps> = ({ node, sourcePaths, typeM
                 return !v;
               });
             }}
-            title={hasLookup ? `Lookup: ${mapping!.lookupDictionary!.entries.length} entries` : 'Add value lookup dictionary'}
+            title={hasLookup ? `Lookup: ${mapping!.lookupDictionary!.entries.length} entries` : 'Map source values to different output values'}
             className={[
-              'flex-shrink-0 text-xs font-mono px-1 rounded border transition',
+              'flex-shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded border transition',
               hasLookup || lookupOpen
                 ? 'border-violet-400 bg-violet-50 text-violet-600'
                 : 'border-gray-200 text-gray-400 hover:border-violet-300 hover:text-violet-500',
             ].join(' ')}
-          >≡</button>
+          >Lookup</button>
         )}
 
         {/* Value / path display based on current mode */}
@@ -246,6 +272,46 @@ export const OutputLeaf: React.FC<OutputLeafProps> = ({ node, sourcePaths, typeM
             onChange={(e) => dispatch(updateFieldMapping({ id: mapping!.id, fixedValue: e.target.value }))}
             onClick={(e) => e.stopPropagation()}
           />
+        ) : currentMode === 'partner' ? (
+          <div className="flex-1 relative min-w-0" onClick={(e) => e.stopPropagation()}>
+            <input
+              list={`partner-props-${mapping?.id}`}
+              className="w-full border-0 bg-transparent font-mono text-xs focus:outline-none text-emerald-600 placeholder-emerald-300"
+              placeholder="property key…"
+              value={mapping?.partnerPropKey ?? ''}
+              onChange={(e) => dispatch(updateFieldMapping({ id: mapping!.id, partnerPropKey: e.target.value }))}
+            />
+            <datalist id={`partner-props-${mapping?.id}`}>
+              {Object.keys(partnerAdapterProperties).map((k) => (
+                <option key={k} value={k} />
+              ))}
+            </datalist>
+          </div>
+        ) : currentMode === 'global' ? (
+          <div className="flex gap-1 flex-1 min-w-0" onClick={(e) => e.stopPropagation()}>
+            <select
+              className="border-0 bg-transparent font-mono text-xs focus:outline-none text-teal-600 flex-1 min-w-0"
+              value={mapping?.globalSetId ?? ''}
+              onChange={(e) => dispatch(updateFieldMapping({ id: mapping!.id, globalSetId: e.target.value, globalKey: '' }))}
+            >
+              <option value="">— pick set —</option>
+              {allGlobalSets.map((s) => (
+                <option key={s.id} value={s.id}>{s.name}</option>
+              ))}
+            </select>
+            {mapping?.globalSetId && (
+              <select
+                className="border-0 bg-transparent font-mono text-xs focus:outline-none text-teal-500 flex-1 min-w-0"
+                value={mapping?.globalKey ?? ''}
+                onChange={(e) => dispatch(updateFieldMapping({ id: mapping!.id, globalKey: e.target.value }))}
+              >
+                <option value="">— pick key —</option>
+                {Object.keys(allGlobalSets.find((s) => s.id === mapping?.globalSetId)?.values ?? {}).map((k) => (
+                  <option key={k} value={k}>{k}</option>
+                ))}
+              </select>
+            )}
+          </div>
         ) : (
           <select
             className="flex-1 border-0 bg-transparent font-mono text-xs focus:outline-none text-gray-500 min-w-0"
@@ -256,6 +322,7 @@ export const OutputLeaf: React.FC<OutputLeafProps> = ({ node, sourcePaths, typeM
                   id: mapping.id,
                   source: e.target.value,
                   fixedValue: undefined,
+                  partnerPropKey: undefined,
                   valuesSetId: undefined,
                   lookupDictionary: undefined,
                 }));
@@ -277,10 +344,10 @@ export const OutputLeaf: React.FC<OutputLeafProps> = ({ node, sourcePaths, typeM
         {/* Transform badge — shown when NOT selected but transform exists */}
         {!isSelected && mapping?.transform && currentMode === 'source' && (
           <span
-            title={`Expression: ${mapping.transform}`}
-            className="flex-shrink-0 text-[10px] font-mono text-violet-600 border border-violet-200 bg-violet-50 rounded px-1 cursor-default"
+            title={`Transform: ${mapping.transform}`}
+            className="flex-shrink-0 text-[10px] font-medium text-violet-600 border border-violet-200 bg-violet-50 rounded px-1 cursor-default"
           >
-            ƒ
+            transform
           </span>
         )}
 
@@ -433,13 +500,13 @@ export const OutputLeaf: React.FC<OutputLeafProps> = ({ node, sourcePaths, typeM
       {/* ── Expression row — only when selected + source mode + source assigned + no lookup active ── */}
       {isSelected && currentMode === 'source' && mapping?.source && !hasLookup && (
         <div
-          className="flex items-center gap-1.5 px-2 pb-1.5"
+          className="px-2 pb-1.5 space-y-0.5"
           onClick={(e) => e.stopPropagation()}
         >
-          <span className="text-[10px] text-violet-500 font-mono flex-shrink-0 w-5 text-center select-none">ƒ</span>
+          <span className="text-[10px] font-medium text-violet-600 select-none">Transform <span className="font-normal text-gray-400">(optional — modify the source value before output)</span></span>
           <input
-            className="flex-1 border border-violet-200 bg-white rounded px-2 py-0.5 text-xs font-mono focus:outline-none focus:border-violet-400 placeholder-gray-300 text-violet-700"
-            placeholder="e.g. value * 1.2  or  value + ' suffix'  — 'value' = source field"
+            className="w-full border border-violet-200 bg-white rounded px-2 py-1 text-xs font-mono focus:outline-none focus:border-violet-400 placeholder-gray-300 text-violet-700"
+            placeholder="e.g.  value * 1.2    or    value + ' USD'    — use 'value' to refer to the source field"
             value={mapping.transform ?? ''}
             onChange={(e) =>
               dispatch(updateFieldMapping({ id: mapping.id, transform: e.target.value || undefined }))

--- a/src/components/MappingEditor/index.tsx
+++ b/src/components/MappingEditor/index.tsx
@@ -216,7 +216,12 @@ const MappingEditorInner: React.FC = () => {
   const assignedFieldCount = useMemo(
     () =>
       fieldMappings.filter(
-        (m) => m.target && (Boolean(m.source) || m.fixedValue !== undefined || Boolean(m.partnerPropKey))
+        (m) =>
+          m.target &&
+          (Boolean(m.source) ||
+            m.fixedValue !== undefined ||
+            Boolean(m.partnerPropKey) ||
+            Boolean(m.globalSetId && m.globalKey))
       ).length,
     [fieldMappings]
   );

--- a/src/components/MappingEditor/index.tsx
+++ b/src/components/MappingEditor/index.tsx
@@ -67,6 +67,7 @@ const MappingEditorInner: React.FC = () => {
     isManualDirty,
     searchInput,
     searchOutput,
+    selectedPartnerId,
   } = useMappingEditorState();
   const { id } = useParams<{ id: string }>();
   const subscriptionId = Number(id);
@@ -215,7 +216,7 @@ const MappingEditorInner: React.FC = () => {
   const assignedFieldCount = useMemo(
     () =>
       fieldMappings.filter(
-        (m) => m.target && (Boolean(m.source) || m.fixedValue !== undefined)
+        (m) => m.target && (Boolean(m.source) || m.fixedValue !== undefined || Boolean(m.partnerPropKey))
       ).length,
     [fieldMappings]
   );
@@ -247,10 +248,10 @@ const MappingEditorInner: React.FC = () => {
       if (!m.target.trim()) {
         errors.push({ type: 'error', message: `Mapping has no target field`, path: m.id });
       }
-      if (!m.source && m.fixedValue === undefined) {
+      if (!m.source && m.fixedValue === undefined && !m.partnerPropKey && !(m.globalSetId && m.globalKey)) {
         errors.push({
           type: 'warning',
-          message: `"${m.target}" has no assigned source or fixed value`,
+          message: `"${m.target}" has no assigned source, fixed value, partner property, or global variable`,
           path: m.target,
         });
       }
@@ -289,6 +290,9 @@ const MappingEditorInner: React.FC = () => {
     if (outputJson.trim()) {
       mapperProperties.push({ key: 'TargetJson', value: outputJson });
     }
+    if (selectedPartnerId != null) {
+      mapperProperties.push({ key: 'PartnerId', value: String(selectedPartnerId) });
+    }
 
     const result = await saveMapper({
       id: subscriptionId,
@@ -309,6 +313,7 @@ const MappingEditorInner: React.FC = () => {
     manualTemplate,
     valuesSetMap,
     subscriptionId,
+    selectedPartnerId,
     saveMapper,
   ]);
 

--- a/src/components/MappingEditor/mappingEditorActions.ts
+++ b/src/components/MappingEditor/mappingEditorActions.ts
@@ -29,6 +29,8 @@ export interface MappingEditorState extends CoreState {
   showPreview: boolean;
   subscriptionId: number | null;
   mapperId: string | null;
+  selectedPartnerId: number | null;
+  partnerAdapterProperties: Record<string, string>;
 }
 
 // ─── Action type union ────────────────────────────────────────────────────────
@@ -62,7 +64,8 @@ export type MappingEditorAction =
   | { type: 'REDO' }
   | { type: 'CLEAR_ALL' }
   | { type: 'AUTO_MATCH' }
-  | { type: 'GENERATE_FROM_TARGET_JSON' };
+  | { type: 'GENERATE_FROM_TARGET_JSON' }
+  | { type: 'SET_SELECTED_PARTNER'; payload: { partnerId: number | null; adapterProperties: Record<string, string> } };
 
 // ─── Action creators ──────────────────────────────────────────────────────────
 
@@ -78,6 +81,7 @@ export const removeFieldMapping = (p: string): MappingEditorAction => ({ type: '
 export const updateFieldMapping = (p: Partial<FieldMapping> & { id: string }): MappingEditorAction => ({ type: 'UPDATE_FIELD_MAPPING', payload: p });
 export const setFieldMappings = (p: FieldMapping[]): MappingEditorAction => ({ type: 'SET_FIELD_MAPPINGS', payload: p });
 export const setArrayMappings = (p: ArrayMapping[]): MappingEditorAction => ({ type: 'SET_ARRAY_MAPPINGS', payload: p });
+export const setSelectedPartner = (partnerId: number | null, adapterProperties: Record<string, string>): MappingEditorAction => ({ type: 'SET_SELECTED_PARTNER', payload: { partnerId, adapterProperties } });
 export const addArrayMapping = (p: Omit<ArrayMapping, 'id'>): MappingEditorAction => ({ type: 'ADD_ARRAY_MAPPING', payload: p });
 export const removeArrayMapping = (p: string): MappingEditorAction => ({ type: 'REMOVE_ARRAY_MAPPING', payload: p });
 export const updateArrayMapping = (p: Partial<ArrayMapping> & { id: string }): MappingEditorAction => ({ type: 'UPDATE_ARRAY_MAPPING', payload: p });

--- a/src/components/MappingEditor/mappingEditorReducer.ts
+++ b/src/components/MappingEditor/mappingEditorReducer.ts
@@ -90,6 +90,9 @@ export function loadFromProps(props: KeyValuePair[]): CoreState {
               valuesSetId: m.valuesSetId ?? undefined,
               isRootSource: m.isRootSource ?? undefined,
               lookupDictionary: m.lookupDictionary ?? undefined,
+              partnerPropKey: m.partnerPropKey ?? undefined,
+              globalSetId: m.globalSetId ?? undefined,
+              globalKey: m.globalKey ?? undefined,
             })),
             fixedItems: Array.isArray(am.fixedItems) ? am.fixedItems : undefined,
           });
@@ -126,6 +129,8 @@ export const initialMappingEditorState: MappingEditorState = {
   showPreview: false,
   subscriptionId: null,
   mapperId: null,
+  selectedPartnerId: null,
+  partnerAdapterProperties: {},
 };
 
 // ─── Reducer ──────────────────────────────────────────────────────────────────
@@ -152,12 +157,16 @@ export function mappingEditorReducer(
           const tjEntry = mapperProperties.find((p) => p.key === 'TargetJson');
           if (sjEntry?.value) draft.inputJson = sjEntry.value;
           if (tjEntry?.value) draft.outputJson = tjEntry.value;
+          const pidEntry = mapperProperties.find((p) => p.key === 'PartnerId');
+          if (pidEntry?.value) draft.selectedPartnerId = Number(pidEntry.value);
         }
         draft.past = [];
         draft.future = [];
         draft.selectedMappingId = null;
         draft.mode = 'visual';
         draft.isManualDirty = false;
+        if (!draft.selectedPartnerId) draft.selectedPartnerId = null;
+        draft.partnerAdapterProperties = {};
         break;
       }
       case 'SET_INPUT_JSON':
@@ -258,6 +267,12 @@ export function mappingEditorReducer(
       case 'TOGGLE_VALIDATION':
         draft.showValidation = !draft.showValidation;
         break;
+      case 'SET_SELECTED_PARTNER': {
+        draft.selectedPartnerId = action.payload.partnerId;
+        draft.partnerAdapterProperties = action.payload.adapterProperties;
+        // Do not clear any partnerPropKey mappings — user manages their own mappings.
+        break;
+      }
       case 'UNDO': {
         if (state.past.length === 0) break;
         const prev = state.past[state.past.length - 1];

--- a/src/components/MappingEditor/types.ts
+++ b/src/components/MappingEditor/types.ts
@@ -33,6 +33,12 @@ export interface FieldMapping {
   lookupDictionary?: LookupDictionary;
   /** True when source points to a root-level field (not an item field of the loop array). */
   isRootSource?: boolean;
+  /** Partner adapter property key — mutually exclusive with source and fixedValue.
+   *  Generates {{ __partner__.<key> | json }} in the Scriban template. */
+  partnerPropKey?: string;  /** Global adapter values set reference — mutually exclusive with other modes.
+   *  Generates {{ __globals__?.SETID?.KEY | json }} in the Scriban template. */
+  globalSetId?: string;
+  globalKey?: string;
 }
 
 export interface ArrayMapping {

--- a/src/state/ReduxSotre.ts
+++ b/src/state/ReduxSotre.ts
@@ -8,6 +8,7 @@ import {GeneralApi} from "src/client/apis/generalApi";
 import {GlobalAdapterValuesSetsApi} from "src/client/apis/globalAdapterValuesSetsApi";
 import {ApiGatewaysApi} from "src/client/apis/apiGatewaysApi";
 import {MappersApi} from "src/client/apis/mappersApi";
+import {PartnersApi} from "src/client/apis/partnersApi";
 import {themeSlice} from "src/state/stateSlices/theme";
 import {featuresSlice} from "src/state/stateSlices/features";
 
@@ -21,7 +22,8 @@ const reducers = combineReducers({
     [GeneralApi.reducerPath]:GeneralApi.reducer,
     [GlobalAdapterValuesSetsApi.reducerPath]: GlobalAdapterValuesSetsApi.reducer,
     [ApiGatewaysApi.reducerPath]: ApiGatewaysApi.reducer,
-    [MappersApi.reducerPath]: MappersApi.reducer
+    [MappersApi.reducerPath]: MappersApi.reducer,
+    [PartnersApi.reducerPath]: PartnersApi.reducer
 
 });
 
@@ -36,7 +38,8 @@ export const store = configureStore({
             GeneralApi.middleware,
             GlobalAdapterValuesSetsApi.middleware,
             ApiGatewaysApi.middleware,
-            MappersApi.middleware
+            MappersApi.middleware,
+            PartnersApi.middleware
         ])
 });
 

--- a/src/utils/scribanGenerator.ts
+++ b/src/utils/scribanGenerator.ts
@@ -82,6 +82,12 @@ function renderFieldValue(
   valuesSetMap?: ValuesSetMap,
   targetType?: 'string' | 'number' | 'boolean'
 ): string {
+  if (mapping.partnerPropKey) {
+    return `{{ __partner__?.${mapping.partnerPropKey} | json }}`;
+  }
+  if (mapping.globalSetId && mapping.globalKey) {
+    return `{{ __globals__?.${mapping.globalSetId}["${mapping.globalKey}"] | json }}`;
+  }
   if (mapping.fixedValue !== undefined) {
     const num = Number(mapping.fixedValue);
     if (!isNaN(num) && mapping.fixedValue.trim() !== '') return String(num);
@@ -179,7 +185,7 @@ export function generateScriban(
 
   // ── Simple field mappings ──────────────────────────────────────────────────
   const validFields = fieldMappings.filter(
-    (m) => m.target.trim() && (m.source.trim() || m.fixedValue !== undefined)
+    (m) => m.target.trim() && (m.source.trim() || m.fixedValue !== undefined || m.partnerPropKey || (m.globalSetId && m.globalKey))
   );
 
   for (const m of validFields) {
@@ -272,7 +278,10 @@ function emitFixedValueLines(v: unknown, pad: string, typeMap?: TypeMap, fieldPa
     if (m) {
       const expr = m[1].trim();
       const targetType = fieldPath ? typeMap?.[fieldPath] : undefined;
-      return targetType
+      // Lookup dict expressions ($__e = ...) must not be wrapped with castExpr —
+      // the assignment+semicolon syntax is invalid inside a parenthesised cast expression.
+      const isLookup = expr.includes('$__e =');
+      return targetType && !isLookup
         ? [`{{ ${castExpr(expr, targetType)} | json }}`]
         : [`{{ ${expr} | json }}`];
     }

--- a/src/utils/scribanParser.ts
+++ b/src/utils/scribanParser.ts
@@ -45,6 +45,18 @@ function parseExpr(
 ): Pick<ParsedFieldMapping, 'source' | 'transform' | 'valuesSetId' | 'isRootSource' | 'lookupDictionary'> {
   const expr = stripJsonPipe(raw.trim());
 
+  // Partner adapter property — {{ __partner__.propkey | json }} or {{ __partner__?.propkey | json }}
+  const partnerMatch = expr.match(/^__partner__\??\.(\w+)$/);
+  if (partnerMatch) {
+    return { source: '', partnerPropKey: partnerMatch[1] };
+  }
+
+  // Global adapter values set — {{ __globals__?.SETID["KEY"] | json }} or {{ __globals__?.SETID?["KEY"] | json }}
+  const globalMatch = expr.match(/^__globals__\??\.([\w]+)\??(?:\.(\w+)|\["([^"]+)"\])$/);
+  if (globalMatch) {
+    return { source: '', globalSetId: globalMatch[1], globalKey: globalMatch[2] ?? globalMatch[3] };
+  }
+
   // Dictionary lookup — $__e = { ... }; ...
   if (valuesSetId || expr.startsWith('$__e')) {
     if (!valuesSetId) {
@@ -203,9 +215,21 @@ export function parseScriban(template: string): ParsedMappings {
 
   const lines = template.split('\n');
   let i = 0;
+  // Track nesting depth so we only create fieldMappings for lines directly
+  // inside the root object (depth === 1).  Lines inside fixed-item literals
+  // (e.g. `"lineOrders": [ { "ref": ... } ]`) sit at depth >= 3 and must not
+  // be mistaken for top-level field mappings.
+  let depth = 0;
 
   while (i < lines.length) {
     const line = lines[i].trim();
+
+    // Update depth for this line, ignoring brackets inside {{ }} expressions.
+    const lineForDepth = line.replace(/\{\{[\s\S]*?\}\}/g, '');
+    for (const ch of lineForDepth) {
+      if (ch === '{' || ch === '[') depth++;
+      else if (ch === '}' || ch === ']') depth--;
+    }
 
     const forMatch = line.match(/\{\{-?\s*for\s+(\w+)\s+in\s+([\w.[\]*]+)\s*-?\}\}/);
     if (forMatch) {
@@ -232,8 +256,10 @@ export function parseScriban(template: string): ParsedMappings {
       continue;
     }
 
+    // Only parse as a top-level field mapping when directly inside the root object.
+    // depth === 1 means we've seen exactly one opening `{` (the root) with no unclosed `[`.
     const simpleMatch = line.match(/"([\w.]+)"\s*:\s*(.*),?$/);
-    if (simpleMatch && !line.includes('{{- for') && !line.startsWith('[') && !line.startsWith(']') && !line.startsWith('{')) {
+    if (simpleMatch && depth === 1 && !line.includes('{{- for') && !line.startsWith('[') && !line.startsWith(']') && !line.startsWith('{')) {
       const target = simpleMatch[1];
       const valueRaw = simpleMatch[2].replace(/,$/, '').trim();
 

--- a/src/utils/scribanParser.ts
+++ b/src/utils/scribanParser.ts
@@ -42,7 +42,7 @@ function parseExpr(
   raw: string,
   valuesSetId: string | undefined,
   alias?: string,
-): Pick<ParsedFieldMapping, 'source' | 'transform' | 'valuesSetId' | 'isRootSource' | 'lookupDictionary'> {
+): Pick<ParsedFieldMapping, 'source' | 'transform' | 'valuesSetId' | 'isRootSource' | 'lookupDictionary' | 'partnerPropKey' | 'globalSetId' | 'globalKey'> {
   const expr = stripJsonPipe(raw.trim());
 
   // Partner adapter property — {{ __partner__.propkey | json }} or {{ __partner__?.propkey | json }}


### PR DESCRIPTION
- Updated LivePreview component to handle partner adapter properties and selected partner ID.
- Modified MappingEditorToolbar to include a partner selector for visual mode, syncing local state with Redux.
- Enhanced OutputLeaf to support partner properties and global variable mappings, including UI updates for mode selection.
- Updated mapping editor state and actions to include selected partner ID and adapter properties.
- Improved scribanGenerator and scribanParser to handle new partner and global variable expressions.
- Adjusted mapping validation to account for partner properties and global variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added support for mapping fields from partner adapter properties
- Added support for mapping fields from global adapter value sets
- Added lookup dictionary functionality for field value mappings
- Added "Test partner" dropdown to validate mappings with different partner configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->