### PR TITLE
fix: revert Node.js version to 22-alpine in Dockerfile for compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build environment
-FROM node:23-alpine as build
+FROM node:22-alpine as build
 WORKDIR /app
 
 COPY package.json /app/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Node.js version for the application build environment from version 23 to version 22 (Alpine Linux variant).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->