### PR TITLE
feat: add support for root-array mappings in the mapping editor

### DIFF
--- a/src/components/MappingEditor/ArrayMappingModal/ArrayMappingModal.tsx
+++ b/src/components/MappingEditor/ArrayMappingModal/ArrayMappingModal.tsx
@@ -25,6 +25,7 @@ const ArrayMappingModal: React.FC = () => {
   const {
     isCreating,
     isNested,
+    isRootOutput,
     parentAmTarget,
     source,
     target,
@@ -90,13 +91,20 @@ const ArrayMappingModal: React.FC = () => {
           <div className="grid grid-cols-3 gap-3">
             <div>
               <label className="block text-xs font-semibold text-gray-600 mb-1">Target Array Path</label>
-              <input
-                className="w-full border border-gray-200 rounded px-2 py-1.5 text-xs font-mono bg-gray-50 text-gray-500 cursor-not-allowed"
-                value={target}
-                readOnly
-                disabled
-                title="Target is determined by the array you clicked in the output tree"
-              />
+              {isRootOutput ? (
+                <div className="w-full border border-blue-200 rounded px-2 py-1.5 text-xs font-mono bg-blue-50 text-blue-600 flex items-center gap-1.5">
+                  <span className="text-[10px] font-bold bg-blue-100 border border-blue-300 text-blue-700 rounded px-1">root</span>
+                  <span className="text-blue-500 italic">output is a root array</span>
+                </div>
+              ) : (
+                <input
+                  className="w-full border border-gray-200 rounded px-2 py-1.5 text-xs font-mono bg-gray-50 text-gray-500 cursor-not-allowed"
+                  value={target}
+                  readOnly
+                  disabled
+                  title="Target is determined by the array you clicked in the output tree"
+                />
+              )}
             </div>
             <div>
               <label className="block text-xs font-semibold text-gray-600 mb-1">Source Array Path</label>
@@ -295,7 +303,7 @@ const ArrayMappingModal: React.FC = () => {
             <button
               onClick={handleSave}
               disabled={
-                !target ||
+                (!target && !isRootOutput) ||
                 (hasFilter && !source) ||
                 pendingMappings.some(
                   (m) => m.target && !m.source && m.fixedValue === undefined && !m.lookupDictionary && !m.partnerPropKey && !(m.globalSetId && m.globalKey)

--- a/src/components/MappingEditor/ArrayMappingModal/useArrayMappingModal.ts
+++ b/src/components/MappingEditor/ArrayMappingModal/useArrayMappingModal.ts
@@ -40,6 +40,7 @@ export interface UseArrayMappingModalResult {
   // Derived state
   isCreating: boolean;
   isNested: boolean;
+  isRootOutput: boolean;
   parentAmTarget: string;
   // Form fields
   source: string;
@@ -92,6 +93,7 @@ export function useArrayMappingModal(): UseArrayMappingModalResult {
     outputJson,
     newArrayPresetTarget,
     newArrayParentId,
+    newArrayIsRootOutput,
     partnerAdapterProperties,
   } = useMappingEditorState();
   const { data: globalSetsData } = useGlobalAdapterValuesSetsQuery({ offset: 0, limit: 1000 });
@@ -119,14 +121,29 @@ export function useArrayMappingModal(): UseArrayMappingModalResult {
 
   const sourceArrayPaths = React.useMemo(() => {
     try {
-      const obj = JSON.parse(inputJson) as Record<string, unknown>;
+      const parsed = JSON.parse(inputJson);
+      if (Array.isArray(parsed)) {
+        if (!parentAm) return ['items'];
+        // Nested inside a root-array AM: find array-valued keys inside the first item
+        if (parsed.length > 0 && typeof parsed[0] === 'object' && parsed[0] !== null) {
+          return Object.entries(parsed[0] as Record<string, unknown>)
+            .filter(([, v]) => Array.isArray(v))
+            .map(([k]) => k);
+        }
+        return [];
+      }
+      const obj = parsed as Record<string, unknown>;
       return parentAm ? getItemArrayPaths(obj, parentFullSource) : collectArrayPaths(obj);
     } catch { return []; }
   }, [inputJson, parentAm, parentFullSource]);
 
   const inputScalarProps = React.useMemo(() => {
     try {
-      const root = JSON.parse(inputJson) as Record<string, unknown>;
+      const parsed = JSON.parse(inputJson);
+      // Root array — expose scalar props from the first element, prefixed with 'item.'
+      const root: Record<string, unknown> = Array.isArray(parsed)
+        ? (parsed.length > 0 && typeof parsed[0] === 'object' && parsed[0] !== null ? parsed[0] as Record<string, unknown> : {})
+        : parsed as Record<string, unknown>;
       const collect = (obj: Record<string, unknown>, prefix: string): string[] => {
         if (obj === null || typeof obj !== 'object' || Array.isArray(obj)) return prefix ? [prefix] : [];
         return Object.entries(obj).flatMap(([k, v]) => {
@@ -142,8 +159,13 @@ export function useArrayMappingModal(): UseArrayMappingModalResult {
 
   const fullSourcePath = React.useMemo(() => {
     if (!source) return '';
+    // 'items' is a virtual C# alias for root-array input — not a real JSON key.
+    // When nested inside a root-array AM, use source directly so path navigation works.
+    if (parentFullSource === 'items') {
+      try { if (Array.isArray(JSON.parse(inputJson))) return source; } catch { /* ignore */ }
+    }
     return parentFullSource ? `${parentFullSource}.${source}` : source;
-  }, [source, parentFullSource]);
+  }, [source, parentFullSource, inputJson]);
 
   const sourceItemProps = React.useMemo(
     () => getItemProperties(inputJson, fullSourcePath),
@@ -152,16 +174,32 @@ export function useArrayMappingModal(): UseArrayMappingModalResult {
 
   const fullTargetBase = React.useMemo(() => {
     const t = am?.target ?? newArrayPresetTarget ?? '';
-    if (!t) return '';
+    // isRootOutput AMs have an empty target — keep as '' (sentinel for root array)
+    if (!t) return newArrayIsRootOutput || am?.isRootOutput ? '__root__' : '';
     if (!newArrayParentId) return t;
     const parentBase = getFullTargetBase(newArrayParentId, arrayMappings);
     return parentBase ? `${parentBase}.${t}` : t;
-  }, [am, newArrayPresetTarget, newArrayParentId, arrayMappings]);
+  }, [am, newArrayPresetTarget, newArrayParentId, newArrayIsRootOutput, arrayMappings]);
 
   const targetItemProps = React.useMemo(() => {
     if (!fullTargetBase) return [];
-    const results: string[] = [...getItemProperties(outputJson, fullTargetBase)];
-    const arrayPrefix = `${fullTargetBase}[*].`;
+    const results: string[] = [];
+    if (fullTargetBase === '__root__') {
+      // Root array output: get scalar/object item properties from the first element,
+      // excluding array-valued keys (those are handled as nested array mappings).
+      try {
+        const parsed = JSON.parse(outputJson);
+        if (Array.isArray(parsed) && parsed.length > 0 && typeof parsed[0] === 'object' && parsed[0] !== null) {
+          const first = parsed[0] as Record<string, unknown>;
+          Object.entries(first)
+            .filter(([, v]) => !Array.isArray(v))
+            .forEach(([k]) => results.push(k));
+        }
+      } catch { /* ignore */ }
+    } else {
+      results.push(...getItemProperties(outputJson, fullTargetBase));
+    }
+    const arrayPrefix = fullTargetBase === '__root__' ? '[*].' : `${fullTargetBase}[*].`;
     fieldMappings
       .map((fm) => fm.target)
       .filter((t) => t.startsWith(arrayPrefix))
@@ -217,7 +255,7 @@ export function useArrayMappingModal(): UseArrayMappingModalResult {
       setPendingMappings([]);
     }
     setOpenPanels({});
-  }, [am, inputScalarProps]);
+  }, [am, inputScalarProps, editingArrayId]);
 
   // ── Actions ────────────────────────────────────────────────────────────────
 
@@ -262,6 +300,7 @@ export function useArrayMappingModal(): UseArrayMappingModalResult {
         filter,
         mappings: cleanMappings(pendingMappings),
         parentArrayId: newArrayParentId ?? undefined,
+        isRootOutput: newArrayIsRootOutput || undefined,
       }));
     } else {
       dispatch(updateArrayMapping({
@@ -271,6 +310,7 @@ export function useArrayMappingModal(): UseArrayMappingModalResult {
         alias: alias || 'item',
         filter,
         mappings: cleanMappings(pendingMappings),
+        isRootOutput: am?.isRootOutput || newArrayIsRootOutput || undefined,
       }));
     }
     dispatch(openArrayModal({ id: null }));
@@ -286,6 +326,7 @@ export function useArrayMappingModal(): UseArrayMappingModalResult {
   return {
     isCreating,
     isNested,
+    isRootOutput: am?.isRootOutput ?? newArrayIsRootOutput,
     parentAmTarget: parentAm?.target ?? '',
     source,
     target: currentTarget,

--- a/src/components/MappingEditor/OutputTree/OutputBranch.tsx
+++ b/src/components/MappingEditor/OutputTree/OutputBranch.tsx
@@ -137,6 +137,7 @@ export const OutputBranch: React.FC<OutputBranchProps> = ({ node, depth = 0, sou
           mappings: [],
           fixedItems: updated,
           parentArrayId: parentAm?.id ?? undefined,
+          isRootOutput: isRootArrayNode || undefined,
         })
       );
     }

--- a/src/components/MappingEditor/OutputTree/OutputBranch.tsx
+++ b/src/components/MappingEditor/OutputTree/OutputBranch.tsx
@@ -48,6 +48,9 @@ export const OutputBranch: React.FC<OutputBranchProps> = ({ node, depth = 0, sou
   // Is this node inside another array? (path like "lineOrders[*].lineItems")
   const isNestedArrayNode = node.type === 'array' && node.path.includes('[*].');
 
+  // Is this the synthetic root-array node (output schema is [...])?
+  const isRootArrayNode = node.key === 'root' && node.path === '[*]';
+
   // Find the parent AM for this node (when nested)
   const parentContainerPath = isNestedArrayNode
     ? node.path.substring(0, node.path.lastIndexOf('[*].') + 3) // e.g. "lineOrders[*]"
@@ -62,7 +65,7 @@ export const OutputBranch: React.FC<OutputBranchProps> = ({ node, depth = 0, sou
   // Relative target name for this node (last segment, no [*])
   const relativeTarget = isNestedArrayNode
     ? node.path.split('[*].').pop()?.replace('[*]', '') ?? node.key
-    : node.key;
+    : isRootArrayNode ? '' : node.key;
 
   // Check if this node corresponds to an array mapping (top-level or nested)
   const arrayMapping = arrayMappings.find((am) => {
@@ -78,7 +81,11 @@ export const OutputBranch: React.FC<OutputBranchProps> = ({ node, depth = 0, sou
   // Scalar (non-array) leaf paths from the root input JSON — for source field suggestions
   const inputScalarProps = React.useMemo(() => {
     try {
-      const root = JSON.parse(inputJson);
+      const parsed = JSON.parse(inputJson);
+      // For root arrays, expose scalar props from the first element
+      const root: Record<string, unknown> = Array.isArray(parsed)
+        ? (parsed.length > 0 && typeof parsed[0] === 'object' && parsed[0] !== null ? parsed[0] as Record<string, unknown> : {})
+        : parsed as Record<string, unknown>;
       const collect = (obj: Record<string, unknown>, prefix: string): string[] => {
         if (obj === null || typeof obj !== 'object' || Array.isArray(obj)) {
           return prefix ? [prefix] : [];
@@ -90,7 +97,7 @@ export const OutputBranch: React.FC<OutputBranchProps> = ({ node, depth = 0, sou
           return [path];
         });
       };
-      return collect(root as Record<string, unknown>, '');
+      return collect(root, '');
     } catch {
       return [];
     }
@@ -102,6 +109,7 @@ export const OutputBranch: React.FC<OutputBranchProps> = ({ node, depth = 0, sou
         id: arrayMapping?.id ?? '__new__',
         presetTarget: relativeTarget,
         parentArrayId: parentAm?.id ?? null,
+        isRootOutput: isRootArrayNode,
       })
     );
   };
@@ -152,7 +160,9 @@ export const OutputBranch: React.FC<OutputBranchProps> = ({ node, depth = 0, sou
           className="flex items-center gap-1 flex-1 text-left"
         >
           <span className="text-gray-400 text-xs w-3 flex-shrink-0">{isOpen ? '▾' : '▸'}</span>
-          <span className="text-xs font-medium text-gray-700 font-mono truncate">{node.key}</span>
+          <span className="text-xs font-medium text-gray-700 font-mono truncate">
+            {isRootArrayNode ? <span className="text-blue-500 italic">root array</span> : node.key}
+          </span>
           {node.type === 'array' && (
             <span className="text-xs text-blue-500 font-mono ml-0.5">[]</span>
           )}

--- a/src/components/MappingEditor/OutputTree/OutputLeaf.tsx
+++ b/src/components/MappingEditor/OutputTree/OutputLeaf.tsx
@@ -33,7 +33,15 @@ export const OutputLeaf: React.FC<OutputLeafProps> = ({ node, sourcePaths, typeM
   const primitiveArrayValues = useMemo((): unknown[] | null => {
     if (isArrayField) return null;
     try {
-      const obj = JSON.parse(outputJson) as Record<string, unknown>;
+      const parsed = JSON.parse(outputJson);
+      // Root primitive array: node.path is '[*]' sentinel (no named key)
+      if (Array.isArray(parsed)) {
+        if (node.path === '[*]' && parsed.every((v) => v === null || typeof v !== 'object')) {
+          return parsed as unknown[];
+        }
+        return null;
+      }
+      const obj = parsed as Record<string, unknown>;
       const cur = node.path.split('.').reduce<unknown>((o, k) => {
         if (o == null || typeof o !== 'object') return undefined;
         return (o as Record<string, unknown>)[k];
@@ -71,7 +79,9 @@ export const OutputLeaf: React.FC<OutputLeafProps> = ({ node, sourcePaths, typeM
 
   // ── Primitive array ───────────────────────────────────────────────────────
   if (primitiveArrayValues !== null) {
-    const primAm = arrayMappings.find((am) => am.target === node.path && !am.parentArrayId && am.primitiveItems);
+    const primAm = node.path === '[*]'
+      ? arrayMappings.find((am) => am.isRootOutput && !am.parentArrayId && am.primitiveItems)
+      : arrayMappings.find((am) => am.target === node.path && !am.parentArrayId && am.primitiveItems);
     const currentItems: PrimitiveArrayItem[] = primAm?.primitiveItems ?? primitiveArrayValues.map(() => ({}));
     return (
       <PrimitiveArrayLeaf

--- a/src/components/MappingEditor/OutputTree/useNormalLeaf.ts
+++ b/src/components/MappingEditor/OutputTree/useNormalLeaf.ts
@@ -120,7 +120,10 @@ export function useNormalLeaf(
 
     if (next === 'fixed') {
       try {
-        fields.fixedValue = getValueAtPath(JSON.parse(outputJson), node.path);
+        const parsedOutput = JSON.parse(outputJson);
+        if (!Array.isArray(parsedOutput)) {
+          fields.fixedValue = getValueAtPath(parsedOutput, node.path);
+        }
       } catch { /* ignore parse errors */ }
     }
 

--- a/src/components/MappingEditor/OutputTree/usePrimitiveArrayLeaf.ts
+++ b/src/components/MappingEditor/OutputTree/usePrimitiveArrayLeaf.ts
@@ -40,17 +40,19 @@ export function usePrimitiveArrayLeaf(
     (item) => item.source || item.fixedValue !== undefined || item.partnerPropKey || (item.globalSetId && item.globalKey),
   ).length;
 
+  const isRootPrimArray = node.path === '[*]';
+
   const saveItem = (idx: number, newItem: PrimitiveArrayItem) => {
     const updated = currentItems.map((item, i) => (i === idx ? newItem : item));
     if (primAmId) {
       dispatch(updateArrayMapping({ id: primAmId, primitiveItems: updated }));
     } else {
-      dispatch(addArrayMapping({ source: '', target: node.path, alias: 'item', mappings: [], primitiveItems: updated }));
+      dispatch(addArrayMapping({ source: '', target: isRootPrimArray ? '' : node.path, alias: 'item', mappings: [], primitiveItems: updated, isRootOutput: isRootPrimArray || undefined }));
     }
   };
 
   const onMapEmptyArray = () => {
-    dispatch(addArrayMapping({ source: '', target: node.path, alias: 'item', mappings: [], primitiveItems: [] }));
+    dispatch(addArrayMapping({ source: '', target: isRootPrimArray ? '' : node.path, alias: 'item', mappings: [], primitiveItems: [], isRootOutput: isRootPrimArray || undefined }));
   };
 
   const onClearEmptyArray = () => {

--- a/src/components/MappingEditor/context/mappingEditorActions.ts
+++ b/src/components/MappingEditor/context/mappingEditorActions.ts
@@ -22,6 +22,7 @@ export interface MappingEditorState extends CoreState {
   editingArrayId: string | null;
   newArrayPresetTarget: string;
   newArrayParentId: string | null;
+  newArrayIsRootOutput: boolean;
   past: CoreState[];
   future: CoreState[];
   validationErrors: ValidationError[];
@@ -56,7 +57,7 @@ export type MappingEditorAction =
   | { type: 'SET_SEARCH_INPUT'; payload: string }
   | { type: 'SET_SEARCH_OUTPUT'; payload: string }
   | { type: 'TOGGLE_NODE_COLLAPSED'; payload: string }
-  | { type: 'OPEN_ARRAY_MODAL'; payload: { id: string | null; presetTarget?: string; parentArrayId?: string | null } }
+  | { type: 'OPEN_ARRAY_MODAL'; payload: { id: string | null; presetTarget?: string; parentArrayId?: string | null; isRootOutput?: boolean } }
   | { type: 'TOGGLE_PREVIEW' }
   | { type: 'SET_VALIDATION_ERRORS'; payload: ValidationError[] }
   | { type: 'TOGGLE_VALIDATION' }
@@ -90,7 +91,7 @@ export const setHoveredPath = (p: string | null): MappingEditorAction => ({ type
 export const setSearchInput = (p: string): MappingEditorAction => ({ type: 'SET_SEARCH_INPUT', payload: p });
 export const setSearchOutput = (p: string): MappingEditorAction => ({ type: 'SET_SEARCH_OUTPUT', payload: p });
 export const toggleNodeCollapsed = (p: string): MappingEditorAction => ({ type: 'TOGGLE_NODE_COLLAPSED', payload: p });
-export const openArrayModal = (p: { id: string | null; presetTarget?: string; parentArrayId?: string | null }): MappingEditorAction => ({ type: 'OPEN_ARRAY_MODAL', payload: p });
+export const openArrayModal = (p: { id: string | null; presetTarget?: string; parentArrayId?: string | null; isRootOutput?: boolean }): MappingEditorAction => ({ type: 'OPEN_ARRAY_MODAL', payload: p });
 export const togglePreview = (): MappingEditorAction => ({ type: 'TOGGLE_PREVIEW' });
 export const setValidationErrors = (p: ValidationError[]): MappingEditorAction => ({ type: 'SET_VALIDATION_ERRORS', payload: p });
 export const toggleValidation = (): MappingEditorAction => ({ type: 'TOGGLE_VALIDATION' });

--- a/src/components/MappingEditor/context/mappingEditorReducer.ts
+++ b/src/components/MappingEditor/context/mappingEditorReducer.ts
@@ -82,6 +82,7 @@ export function loadFromProps(props: KeyValuePair[]): CoreState {
             alias: am.alias ?? 'item',
             filter: am.filter,
             parentArrayId: am.parentArrayId ?? undefined,
+            isRootOutput: am.isRootOutput ?? undefined,
             mappings: (am.mappings ?? []).map((m: any, j: number) => ({
               id: `arr-loaded-${i}-${j}`,
               source: m.source ?? '',
@@ -124,6 +125,7 @@ export const initialMappingEditorState: MappingEditorState = {
   editingArrayId: null,
   newArrayPresetTarget: '',
   newArrayParentId: null,
+  newArrayIsRootOutput: false,
   past: [],
   future: [],
   validationErrors: [],
@@ -258,6 +260,7 @@ export function mappingEditorReducer(
         draft.editingArrayId = action.payload.id;
         draft.newArrayPresetTarget = action.payload.presetTarget ?? '';
         draft.newArrayParentId = action.payload.parentArrayId ?? null;
+        draft.newArrayIsRootOutput = action.payload.isRootOutput ?? false;
         break;
       case 'TOGGLE_PREVIEW':
         draft.showPreview = !draft.showPreview;

--- a/src/components/MappingEditor/index.tsx
+++ b/src/components/MappingEditor/index.tsx
@@ -85,7 +85,12 @@ const MappingEditorInner: React.FC = () => {
     // Use target JSON as the base structure when available, then merge in any
     // manually-added fields from fieldMappings that aren't already in the JSON.
     const basePaths: string[] = outputObj
-      ? buildTree(outputObj).flatMap(flattenLeafPaths)
+      ? (Array.isArray(outputObj)
+          // Root-array output schema: always include the '[*]' container node.
+          // buildTree returns no children for primitive arrays (e.g. [1,2,3]),
+          // so the tree shows just `root []` with the + fixed button.
+          ? ['[*]', ...buildTree(outputObj).flatMap(flattenLeafPaths).map((p) => `[*].${p}`)]
+          : buildTree(outputObj).flatMap(flattenLeafPaths))
       : fieldMappings.map((m) => m.target).filter(Boolean);
 
     // Merge manually-added mapping targets that aren't already in the base set
@@ -101,6 +106,14 @@ const MappingEditorInner: React.FC = () => {
 
     const paths = basePaths;
     for (const am of arrayMappings) {
+      if (am.isRootOutput) {
+        // Root-output AM has no named target — its container path is '[*]'
+        if (!paths.includes('[*]')) paths.push('[*]');
+        for (const m of am.mappings) {
+          if (m.target) paths.push(`[*].${m.target}`);
+        }
+        continue;
+      }
       if (!am.target) continue;
       const fullPrefix = getFullTargetPrefix(am.id, arrayMappings);
       const containerPath = `${fullPrefix}[*]`;

--- a/src/types/mapping.ts
+++ b/src/types/mapping.ts
@@ -64,6 +64,12 @@ export interface ArrayMapping {
   primitiveItems?: PrimitiveArrayItem[];
   /** ID of the parent ArrayMapping. undefined/null means top-level. */
   parentArrayId?: string;
+  /**
+   * When true this ArrayMapping owns the root `[...]` output instead of a
+   * named field.  Only valid on top-level AMs (no parentArrayId).
+   * Generator emits `[ for … ]` instead of `"target": [ for … ]`.
+   */
+  isRootOutput?: boolean;
 }
 
 export type ValidationError = {

--- a/src/utils/__tests__/scribanRootArray.test.ts
+++ b/src/utils/__tests__/scribanRootArray.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Root-array mapping tests.
+ * Covers:
+ *  A) Generator output — verify generated Scriban template strings
+ *  B) Parser round-trip — generate → parse → re-generate produces equivalent output
+ *  C) All 4 modes (source / fixed / partner / global) + lookup + transform
+ *  D) Primitive root arrays
+ *  E) Filter support
+ *  F) Nested arrays inside root-array items
+ */
+import { describe, it, expect } from 'vitest';
+import { generateScriban } from '../scribanGenerator';
+import { parseScriban, resolveParentArrayIds } from '../scribanParser';
+import { FieldMapping, ArrayMapping } from 'src/types/mapping';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+let _id = 0;
+function id() { return `t-${++_id}`; }
+
+function am(overrides: Partial<ArrayMapping> & { source: string; alias: string }): ArrayMapping {
+  return {
+    id: id(),
+    target: '',
+    mappings: [],
+    isRootOutput: true,
+    ...overrides,
+  };
+}
+
+function field(o: Partial<FieldMapping> & { target: string; source: string }): FieldMapping {
+  return { id: id(), ...o };
+}
+
+function roundTrip(arrayMappings: ArrayMapping[]) {
+  const template = generateScriban([], arrayMappings);
+  const parsed = parseScriban(template);
+  const withIds = parsed.arrayMappings.map((a) => ({ ...a, id: id() }));
+  const resolved = resolveParentArrayIds(withIds);
+  return { template, parsed, arrayMappings: resolved };
+}
+
+// ─── A. Generator output ─────────────────────────────────────────────────────
+
+describe('generator: root-array output', () => {
+  it('emits root [ ] when isRootOutput=true', () => {
+    const t = generateScriban([], [am({
+      source: 'items', alias: 'item',
+      mappings: [field({ target: 'id', source: 'Id' })],
+    })]);
+
+    expect(t.trim()).toMatch(/^\[/);
+    expect(t.trim()).toMatch(/\]$/);
+    expect(t).toContain('for item in items');
+    expect(t).toContain('"id": {{ item.Id | json }}');
+  });
+
+  it('does NOT emit wrapping { } object', () => {
+    const t = generateScriban([], [am({
+      source: 'items', alias: 'item',
+      mappings: [field({ target: 'id', source: 'Id' })],
+    })]);
+
+    expect(t.trim()).not.toMatch(/^\{/);
+  });
+
+  it('fieldMappings are ignored when isRootOutput AM is present', () => {
+    const t = generateScriban(
+      [field({ target: 'shouldBeIgnored', source: 'x' })],
+      [am({ source: 'items', alias: 'item', mappings: [] })],
+    );
+
+    expect(t).not.toContain('shouldBeIgnored');
+  });
+
+  it('source mode: item field reference', () => {
+    const t = generateScriban([], [am({
+      source: 'orders', alias: 'order',
+      mappings: [field({ target: 'orderId', source: 'OrderId' })],
+    })]);
+
+    expect(t).toContain('"orderId": {{ order.OrderId | json }}');
+  });
+
+  it('fixed mode: string value', () => {
+    const t = generateScriban([], [am({
+      source: 'items', alias: 'item',
+      mappings: [field({ target: 'type', source: '', fixedValue: 'order' })],
+    })]);
+
+    expect(t).toContain('"type": "order"');
+  });
+
+  it('fixed mode: numeric value', () => {
+    const t = generateScriban([], [am({
+      source: 'items', alias: 'item',
+      mappings: [field({ target: 'version', source: '', fixedValue: '42' })],
+    })]);
+
+    expect(t).toContain('"version": 42');
+  });
+
+  it('partner mode', () => {
+    const t = generateScriban([], [am({
+      source: 'items', alias: 'item',
+      mappings: [field({ target: 'env', source: '', partnerPropKey: 'environment' })],
+    })]);
+
+    expect(t).toContain('"env": {{ __partner__?.environment | json }}');
+  });
+
+  it('global mode', () => {
+    const t = generateScriban([], [am({
+      source: 'items', alias: 'item',
+      mappings: [field({ target: 'region', source: '', globalSetId: 'mySet', globalKey: 'region' })],
+    })]);
+
+    expect(t).toContain('"region": {{ __globals__?.mySet["region"] | json }}');
+  });
+
+  it('lookup — null fallback', () => {
+    const t = generateScriban([], [am({
+      source: 'items', alias: 'item',
+      mappings: [field({
+        target: 'label', source: 'Status',
+        lookupDictionary: { entries: [{ from: 'A', to: 'Active' }], fallback: 'null' },
+      })],
+    })]);
+
+    expect(t).toContain('$__e = { "A": "Active" }');
+    expect(t).toContain('$__e[item.Status]');
+  });
+
+  it('lookup — custom fallback', () => {
+    const t = generateScriban([], [am({
+      source: 'items', alias: 'item',
+      mappings: [field({
+        target: 'label', source: 'Code',
+        lookupDictionary: { entries: [{ from: 'A', to: 'Alpha' }], fallback: 'custom', fallbackValue: 'Unknown' },
+      })],
+    })]);
+
+    expect(t).toContain('"Unknown"');
+    expect(t).toContain('??');
+  });
+
+  it('filter — emits if block inside loop', () => {
+    const t = generateScriban([], [am({
+      source: 'orders', alias: 'order',
+      filter: { field: 'Active', operator: '==', value: 'true' },
+      mappings: [field({ target: 'id', source: 'Id' })],
+    })]);
+
+    expect(t).toContain('if order.Active == "true"');
+  });
+
+  it('primitive root array via source loop', () => {
+    const t = generateScriban([], [{
+      id: id(),
+      target: '',
+      source: 'tags',
+      alias: 'tag',
+      isRootOutput: true,
+      mappings: [],
+      primitiveItems: [{ source: 'tags' }],
+    }]);
+
+    expect(t.trim()).toMatch(/^\[/);
+    // primitive items are emitted as raw {{ path | json }} lines
+    expect(t).toContain('{{ tags | json }}');
+  });
+});
+
+// ─── B. Parser round-trip ────────────────────────────────────────────────────
+
+describe('parser: root-array template round-trip', () => {
+  it('detects isRootOutput=true when template starts with [', () => {
+    const template = `[
+{{- for item in items -}}
+{
+  "id": {{ item.Id | json }},
+},
+{{- end -}}
+]`;
+    const { arrayMappings } = parseScriban(template);
+
+    expect(arrayMappings).toHaveLength(1);
+    expect(arrayMappings[0].isRootOutput).toBe(true);
+    expect(arrayMappings[0].source).toBe('items');
+    expect(arrayMappings[0].alias).toBe('item');
+    expect(arrayMappings[0].target).toBe('');
+  });
+
+  it('parses field mappings inside the root loop', () => {
+    const template = `[
+{{- for order in orders -}}
+{
+  "orderId": {{ order.OrderId | json }},
+  "status": "ACTIVE",
+},
+{{- end -}}
+]`;
+    const { arrayMappings } = parseScriban(template);
+
+    expect(arrayMappings[0].mappings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ target: 'orderId', source: 'OrderId' }),
+        expect.objectContaining({ target: 'status', fixedValue: 'ACTIVE' }),
+      ])
+    );
+  });
+
+  it('round-trips source mapping through generate → parse', () => {
+    const original: ArrayMapping[] = [am({
+      source: 'orders', alias: 'order',
+      mappings: [
+        field({ target: 'id', source: 'OrderId' }),
+        field({ target: 'status', source: '', fixedValue: 'pending' }),
+      ],
+    })];
+
+    const { arrayMappings } = roundTrip(original);
+
+    expect(arrayMappings).toHaveLength(1);
+    expect(arrayMappings[0].isRootOutput).toBe(true);
+    expect(arrayMappings[0].source).toBe('orders');
+    expect(arrayMappings[0].mappings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ target: 'id', source: 'OrderId' }),
+        expect.objectContaining({ target: 'status', fixedValue: 'pending' }),
+      ])
+    );
+  });
+
+  it('round-trips partner mapping', () => {
+    const original: ArrayMapping[] = [am({
+      source: 'items', alias: 'item',
+      mappings: [field({ target: 'env', source: '', partnerPropKey: 'environment' })],
+    })];
+
+    const { arrayMappings } = roundTrip(original);
+
+    expect(arrayMappings[0].mappings[0]).toMatchObject({ target: 'env', partnerPropKey: 'environment' });
+  });
+
+  it('round-trips global mapping', () => {
+    const original: ArrayMapping[] = [am({
+      source: 'items', alias: 'item',
+      mappings: [field({ target: 'region', source: '', globalSetId: 'mySet', globalKey: 'region' })],
+    })];
+
+    const { arrayMappings } = roundTrip(original);
+
+    expect(arrayMappings[0].mappings[0]).toMatchObject({ globalSetId: 'mySet', globalKey: 'region' });
+  });
+
+  it('round-trips lookup with null fallback', () => {
+    const original: ArrayMapping[] = [am({
+      source: 'items', alias: 'item',
+      mappings: [field({
+        target: 'label', source: 'Code',
+        lookupDictionary: { entries: [{ from: 'A', to: 'Alpha' }, { from: 'B', to: 'Beta' }], fallback: 'null' },
+      })],
+    })];
+
+    const { arrayMappings } = roundTrip(original);
+    const m = arrayMappings[0].mappings[0];
+
+    expect(m.lookupDictionary?.fallback).toBe('null');
+    expect(m.lookupDictionary?.entries).toEqual([
+      { from: 'A', to: 'Alpha' },
+      { from: 'B', to: 'Beta' },
+    ]);
+  });
+
+  it('round-trips lookup with custom fallback', () => {
+    const original: ArrayMapping[] = [am({
+      source: 'items', alias: 'item',
+      mappings: [field({
+        target: 'label', source: 'Code',
+        lookupDictionary: { entries: [{ from: 'A', to: 'Alpha' }], fallback: 'custom', fallbackValue: 'Unknown' },
+      })],
+    })];
+
+    const { arrayMappings } = roundTrip(original);
+    const m = arrayMappings[0].mappings[0];
+
+    expect(m.lookupDictionary?.fallback).toBe('custom');
+    expect(m.lookupDictionary?.fallbackValue).toBe('Unknown');
+  });
+
+  it('does NOT return fieldMappings for a root-array template', () => {
+    const template = `[
+{{- for item in items -}}
+{
+  "id": {{ item.Id | json }},
+},
+{{- end -}}
+]`;
+    const { fieldMappings } = parseScriban(template);
+
+    expect(fieldMappings).toHaveLength(0);
+  });
+
+  it('normal (non-root-array) template is unaffected', () => {
+    const template = `{
+  "orderId": {{ orderId | json }},
+}`;
+    const { fieldMappings, arrayMappings } = parseScriban(template);
+
+    expect(fieldMappings).toHaveLength(1);
+    expect(fieldMappings[0]).toMatchObject({ target: 'orderId', source: 'orderId' });
+    expect(arrayMappings).toHaveLength(0);
+  });
+
+  it('generates template that starts with [ when isRootOutput=true and re-parsed produces same AM count', () => {
+    const original: ArrayMapping[] = [am({
+      source: 'items', alias: 'item',
+      mappings: [field({ target: 'x', source: 'X' })],
+    })];
+    const t1 = generateScriban([], original);
+    const { arrayMappings: parsed1 } = parseScriban(t1);
+    const withIds = parsed1.map((a) => ({ ...a, id: id() }));
+    const t2 = generateScriban([], withIds.map((a) => ({ ...a, mappings: a.mappings.map((m) => ({ ...m, id: id() })) })));
+
+    // Both templates should start with [
+    expect(t1.trim()[0]).toBe('[');
+    expect(t2.trim()[0]).toBe('[');
+    // Both should contain the same field reference
+    expect(t1).toContain('item.X');
+    expect(t2).toContain('item.X');
+  });
+});

--- a/src/utils/mappingPreview.ts
+++ b/src/utils/mappingPreview.ts
@@ -19,12 +19,19 @@ export function buildTree(obj: any, keyName = '', prefix = ''): TreeNode[] {
     if (obj.length === 0 || typeof obj[0] !== 'object' || obj[0] === null) {
       return keyName ? [{ key: keyName, path: prefix, type: 'leaf', value: obj, children: [] }] : [];
     }
+    const itemPrefix = prefix ? `${prefix}[*]` : '[*]';
     const children = Object.entries(obj[0] as object).flatMap(([k, v]) =>
-      buildTree(v, k, prefix ? `${prefix}[*].${k}` : k)
+      // When the array is the root (no parent prefix), children are directly
+      // accessible via hoisting — use plain `k` so source paths are e.g. "OrderId"
+      // instead of "[*].OrderId" (which produces invalid Scriban "{{ .OrderId }}").
+      buildTree(v, k, prefix ? `${itemPrefix}.${k}` : k)
     );
-    return keyName
-      ? [{ key: keyName, path: prefix, type: 'array', itemCount: obj.length, children }]
-      : children;
+    if (keyName) {
+      return [{ key: keyName, path: prefix, type: 'array', itemCount: obj.length, children }];
+    }
+    // Root-level array (no keyName): return a synthetic root array node so the
+    // output tree can show a "Configure Loop" button at the root.
+    return [{ key: 'root', path: '[*]', type: 'array', itemCount: obj.length, children }];
   }
   if (typeof obj === 'object') {
     const entries = Object.entries(obj as object).flatMap(([k, v]) =>

--- a/src/utils/mappingTreeUtils.ts
+++ b/src/utils/mappingTreeUtils.ts
@@ -46,7 +46,9 @@ export function insertNode(
   if (parts.length === 0) return;
   const rawPart = parts[0];
   const isArray = rawPart.includes('[*]') || rawPart.includes('[]');
-  const key = rawPart.replace(/\[\*\]|\[\]/g, '');
+  // When rawPart is purely '[*]' (root array), key would be empty — use 'root' to match
+  // the synthetic node created by buildTree() so isRootArrayNode detection works correctly.
+  const key = rawPart.replace(/\[\*\]|\[\]/g, '') || 'root';
   const currentPath = parentPath ? `${parentPath}.${rawPart}` : rawPart;
 
   let existing = nodes.find((n) => n.key === key);
@@ -60,6 +62,9 @@ export function insertNode(
   if (!existing) {
     existing = { key, path: currentPath, type: isArray ? 'array' : 'object', children: [] };
     nodes.push(existing);
+  } else if (existing.type === 'leaf') {
+    // Upgrade leaf to container when it gains children
+    existing.type = isArray ? 'array' : 'object';
   }
   insertNode(existing.children, parts.slice(1), depth + 1, currentPath);
 }

--- a/src/utils/scribanGenerator.ts
+++ b/src/utils/scribanGenerator.ts
@@ -24,9 +24,15 @@ function walkTypeMap(node: any, prefix: string): TypeMap {
     if (node.length === 0) return {};
     const first = node[0];
     if (typeof first !== 'object') {
-      // primitive array — record the element type at this prefix (e.g. "prices[*]" → "number")
+      // primitive array — record the element type at this prefix.
+      // Named arrays are called with prefix already containing "[*]" (e.g. "prices[*]").
+      // Root primitive arrays are called with prefix="" → use "[*]" as key so the
+      // generator's `itemPrefix` ("[*]") resolves the type correctly.
       const t = typeof first;
-      if (prefix && (t === 'string' || t === 'number' || t === 'boolean')) return { [prefix]: t };
+      if (t === 'string' || t === 'number' || t === 'boolean') {
+        const key = prefix || '[*]';
+        return { [key]: t };
+      }
       return {};
     }
     return walkTypeMap(first, prefix); // use first element as representative
@@ -178,7 +184,7 @@ function renderFieldValue(
   // plain path — apply type cast when target type is known
   const path = alias
     ? `${alias}.${src}`
-    : src.replace(/\[?\*\]?/g, '');
+    : src.replace(/\[?\*\]?/g, '').replace(/^\.+/, ''); // strip [*] and any leading dot
 
   if (targetType) {
     // same type — no cast needed
@@ -210,6 +216,15 @@ export function generateScriban(
 ): string {
   const typeMap: TypeMap = outputJson ? buildTypeMap(outputJson) : {};
   const sourceTypeMap: TypeMap = inputJson ? buildTypeMap(inputJson) : {};
+
+  // ── Root-array output: single top-level AM with isRootOutput=true ──────────
+  // When present, the whole template is just `[ ... ]` with no wrapping object.
+  // Field mappings are ignored in this mode (root output is an array, not an object).
+  const rootOutputAm = arrayMappings.find((am) => am.isRootOutput && !am.parentArrayId);
+  if (rootOutputAm) {
+    return renderRootArrayMapping(rootOutputAm, arrayMappings, valuesSetMap, typeMap, inputJson, sourceTypeMap);
+  }
+
   const rootLines: string[] = ['{'];
 
   // ── Simple field mappings ──────────────────────────────────────────────────
@@ -377,6 +392,111 @@ function emitFixedValueLines(v: unknown, pad: string, typeMap?: TypeMap, fieldPa
   const primitiveTargetType = fieldPath ? typeMap?.[fieldPath] : undefined;
   if (primitiveTargetType !== undefined) return [JSON.stringify(coerceFixedValue(v, primitiveTargetType))];
   return [JSON.stringify(v)];
+}
+
+/**
+ * Renders a root-array template: the entire output is `[ ... ]` with no wrapping object.
+ * Used when ArrayMapping.isRootOutput = true.
+ * The loop body and field rendering are identical to renderArrayMapping; only the outer
+ * container changes from `"target": [ ... ]` to just `[ ... ]`.
+ */
+function renderRootArrayMapping(
+  am: ArrayMapping,
+  allAMs: ArrayMapping[],
+  valuesSetMap?: ValuesSetMap,
+  typeMap?: TypeMap,
+  inputJson?: string,
+  sourceTypeMap?: TypeMap
+): string {
+  const alias = am.alias || 'item';
+  const source = am.source;
+
+  // Build the item type-map prefix — for root output we use the source path directly
+  // (e.g. "items[*]" when source is "items", or just "[*]" when input is a root array)
+  const itemPrefix = source ? `${source}[*]` : '[*]';
+
+  const filterExpr = am.filter
+    ? `${alias}.${am.filter.field} ${OPERATOR_MAP[am.filter.operator] ?? am.filter.operator} ${
+        typeof am.filter.value === 'number' ? am.filter.value : `"${am.filter.value}"`
+      }`
+    : '';
+
+  const lines: string[] = ['['];
+
+  // ── Primitive root array (no loop variable needed in the item body) ────────
+  if (am.primitiveItems != null) {
+    for (const item of am.primitiveItems) {
+      const elemType = typeMap?.[itemPrefix];
+      if (item.partnerPropKey) {
+        lines.push(elemType === 'number' || elemType === 'boolean'
+          ? '  null,'
+          : `  {{ __partner__?.${item.partnerPropKey} | json }},`);
+      } else if (item.globalSetId && item.globalKey) {
+        lines.push(elemType === 'number' || elemType === 'boolean'
+          ? '  null,'
+          : `  {{ __globals__?.${item.globalSetId}["${item.globalKey}"] | json }},`);
+      } else if (item.source?.trim()) {
+        const path = item.source.trim();
+        if (item.transform?.trim()) {
+          const expr = item.transform.trim().replace(/\bvalue\b/g, path);
+          lines.push(`  {{ ${expr} | json }},`);
+        } else {
+          lines.push(`  {{ ${path} | json }},`);
+        }
+      } else if (item.fixedValue !== undefined) {
+        lines.push(`  ${JSON.stringify(coerceFixedValue(item.fixedValue, typeMap?.[itemPrefix]))},`);
+      } else {
+        lines.push('  null,');
+      }
+    }
+    lines.push(']');
+    return lines.join('\n');
+  }
+
+  // ── Fixed items before the dynamic loop ───────────────────────────────────
+  if (am.fixedItems?.length) {
+    for (const rawItem of am.fixedItems) {
+      const enriched = enrichFixedItem(rawItem as Record<string, unknown>, am, allAMs);
+      if (!hasDynamicDeep(enriched)) {
+        lines.push(`  ${JSON.stringify(enriched)},`);
+      } else {
+        lines.push('  {');
+        for (const [k, v] of Object.entries(enriched)) {
+          const fp = `${itemPrefix}.${k}`;
+          const vLines = emitFixedValueLines(v, '    ', typeMap, fp, sourceTypeMap, source ? `${source}[*]` : '');
+          lines.push(`    "${k}": ${vLines[0]}${vLines.length === 1 ? ',' : ''}`);
+          for (let li = 1; li < vLines.length - 1; li++) lines.push(vLines[li]);
+          if (vLines.length > 1) lines.push(`${vLines[vLines.length - 1]},`);
+        }
+        lines.push('  },');
+      }
+    }
+  }
+
+  if (!source) {
+    lines.push(']');
+    return lines.join('\n');
+  }
+
+  lines.push(`{{- for ${alias} in ${source} -}}`);
+  if (am.filter) lines.push(`{{- if ${filterExpr} -}}`);
+  lines.push('{');
+  for (const m of am.mappings) {
+    if (!m.target.trim()) continue;
+    const targetType = typeMap?.[`${itemPrefix}.${m.target}`];
+    const sourceType = m.source ? sourceTypeMap?.[`${itemPrefix}.${m.source}`] : undefined;
+    lines.push(`  "${m.target}": ${renderFieldValue(m, alias, valuesSetMap, targetType, sourceType)},`);
+  }
+  // Render child AMs recursively inside this loop body
+  const children = allAMs.filter((c) => c.parentArrayId === am.id && c.source && c.target);
+  for (const child of children) {
+    lines.push(...renderArrayMapping(child, allAMs, alias, 1, valuesSetMap, typeMap, inputJson, sourceTypeMap));
+  }
+  lines.push('},');
+  if (am.filter) lines.push('{{- end -}}');
+  lines.push('{{- end -}}');
+  lines.push(']');
+  return lines.join('\n');
 }
 
 /**

--- a/src/utils/scribanParser.ts
+++ b/src/utils/scribanParser.ts
@@ -7,6 +7,8 @@ export type ParsedArrayMapping = {
   alias: string;
   filter?: ArrayMapping['filter'];
   mappings: ParsedFieldMapping[];
+  /** When true, this AM owns the root `[...]` output — no wrapping object. */
+  isRootOutput?: boolean;
   /** Target of the parent AM — used to resolve parentArrayId after IDs are assigned. */
   parentTarget?: string;
 };
@@ -213,6 +215,40 @@ export function parseScriban(template: string): ParsedMappings {
 
   const lines = template.split('\n');
   let i = 0;
+
+  // ── Root-array template detection ────────────────────────────────────────
+  // A root-array template starts with `[` (ignoring whitespace) and contains
+  // a single top-level `for` loop whose body produces array items.
+  // We detect this upfront and parse it as a single AM with isRootOutput=true.
+  const firstContentLine = lines.find((l) => l.trim() !== '');
+  if (firstContentLine?.trim() === '[') {
+    // Find the for-loop line
+    const forLineIdx = lines.findIndex((l) => /\{\{-?\s*for\s+/.test(l));
+    if (forLineIdx !== -1) {
+      const forMatch = lines[forLineIdx].trim().match(/\{\{-?\s*for\s+(\w+)\s+in\s+([\w.[\]*]+)\s*-?\}\}/);
+      if (forMatch) {
+        const alias = forMatch[1];
+        const source = forMatch[2];
+        const { result, endI } = parseForBody(lines, forLineIdx + 1, alias, '', arrayMappings);
+        // Consume any filter line that may appear before the body
+        arrayMappings.push({
+          source,
+          target: '',
+          alias,
+          isRootOutput: true,
+          filter: result.filter,
+          mappings: result.mappings,
+        });
+        // Any lines after {{- end -}} ] are ignored (should be just `]`)
+        void endI;
+        return { fieldMappings, arrayMappings, warnings };
+      }
+    }
+    // If no for loop found, return empty (fixed-only root array — not yet supported in visual editor)
+    warnings.push('Root-array template has no for-loop — cannot parse back to visual mappings');
+    return { fieldMappings, arrayMappings, warnings };
+  }
+
   // Track nesting depth so we only create fieldMappings for lines directly
   // inside the root object (depth === 1).  Lines inside fixed-item literals
   // (e.g. `"lineOrders": [ { "ref": ... } ]`) sit at depth >= 3 and must not


### PR DESCRIPTION
- Introduced `isRootOutput` flag in ArrayMapping to indicate root-array mappings.
- Updated `useArrayMappingModal` to handle root-array logic, including target path adjustments and item properties.
- Enhanced OutputTree components to recognize and display root-array nodes correctly.
- Modified Scriban generator and parser to support root-array templates, ensuring proper output formatting.
- Added comprehensive tests for root-array functionality, covering generator output, parser round-trip, and various mapping modes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for root-level array outputs in the mapping editor. Users can now configure mappings to generate arrays as top-level outputs rather than wrapping them in objects.

* **Improvements**
  * Enhanced array item path handling and template generation for root-array scenarios.
  * Improved UI to clearly distinguish root array mappings in the modal interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->