### PR TITLE
fix: skip target validation and improve warning label for root-array …

### DIFF
--- a/src/components/MappingEditor/useSave.ts
+++ b/src/components/MappingEditor/useSave.ts
@@ -61,12 +61,13 @@ export function useSave(subscriptionId: number): UseSaveResult {
     for (const am of arrayMappings) {
       if (!am.source && !am.fixedItems?.length && am.primitiveItems == null)
         errors.push({ type: 'error', message: `Array mapping missing source path` });
-      if (!am.target)
+      if (!am.target && !am.isRootOutput)
         errors.push({ type: 'error', message: `Array mapping missing target path` });
       if (am.mappings.length === 0 && !am.fixedItems?.length && am.primitiveItems == null) {
+        const label = am.isRootOutput ? `root array (${am.source})` : `${am.source} → ${am.target}`;
         errors.push({
           type: 'warning',
-          message: `Array mapping "${am.source} → ${am.target}" has no field mappings`,
+          message: `Array mapping "${label}" has no field mappings`,
         });
       }
     }


### PR DESCRIPTION
…mappings in useSave

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Updated array mapping validation to differentiate handling between root output arrays and standard arrays—root arrays no longer require a target path specification.
* Enhanced warning message formatting for array mappings to display more descriptive labels that clearly distinguish between root and non-root array configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->