### PR TITLE
fix: apply type casts correctly for root-array output mappings

### DIFF
--- a/src/utils/__tests__/scribanRootArray.test.ts
+++ b/src/utils/__tests__/scribanRootArray.test.ts
@@ -8,7 +8,6 @@
  *  E) Filter support
  *  F) Nested arrays inside root-array items
  */
-import { describe, it, expect } from 'vitest';
 import { generateScriban } from '../scribanGenerator';
 import { parseScriban, resolveParentArrayIds } from '../scribanParser';
 import { FieldMapping, ArrayMapping } from 'src/types/mapping';
@@ -329,5 +328,69 @@ describe('parser: root-array template round-trip', () => {
     // Both should contain the same field reference
     expect(t1).toContain('item.X');
     expect(t2).toContain('item.X');
+  });
+});
+
+// ─── G. Type casting with root-array output ──────────────────────────────────
+
+describe('type casting: root-array output', () => {
+  it('string source → number target applies to_float', () => {
+    const inputJson = JSON.stringify({ items: [{ price: '19.99' }] });
+    const outputJson = JSON.stringify([{ total: 0.0 }]);
+
+    const t = generateScriban([], [am({
+      source: 'items', alias: 'item',
+      mappings: [field({ target: 'total', source: 'price' })],
+    })], undefined, outputJson, inputJson);
+
+    expect(t).toContain('to_float');
+  });
+
+  it('number source → string target applies "" + cast', () => {
+    const inputJson = JSON.stringify({ items: [{ qty: 5 }] });
+    const outputJson = JSON.stringify([{ qty: '' }]);
+
+    const t = generateScriban([], [am({
+      source: 'items', alias: 'item',
+      mappings: [field({ target: 'qty', source: 'qty' })],
+    })], undefined, outputJson, inputJson);
+
+    expect(t).toMatch(/"qty":.*"" \+/);
+  });
+
+  it('same type (number → number) emits no cast', () => {
+    const inputJson = JSON.stringify({ items: [{ id: 1 }] });
+    const outputJson = JSON.stringify([{ id: 0 }]);
+
+    const t = generateScriban([], [am({
+      source: 'items', alias: 'item',
+      mappings: [field({ target: 'id', source: 'id' })],
+    })], undefined, outputJson, inputJson);
+
+    expect(t).toContain('"id": {{ item.id | json }}');
+    expect(t).not.toContain('to_float');
+  });
+
+  it('nested array: number source → string target applies "" + cast', () => {
+    const inputJson = JSON.stringify([{ OrderId: 1, LineItems: [{ SKU: 'ABC', Qty: 2 }] }]);
+    const outputJson = JSON.stringify([{ orderId: 0, lines: [{ sku: '', qty: '0' }] }]);
+
+    const rootAm: ArrayMapping = {
+      id: 'root', isRootOutput: true, source: 'items', alias: 'item', target: '',
+      mappings: [field({ target: 'orderId', source: 'OrderId' })],
+    };
+    const linesAm: ArrayMapping = {
+      id: 'lines', parentArrayId: 'root', source: 'LineItems', alias: 'line', target: 'lines',
+      mappings: [
+        field({ target: 'sku', source: 'SKU' }),
+        field({ target: 'qty', source: 'Qty' }),
+      ],
+    };
+
+    const t = generateScriban([], [rootAm, linesAm], undefined, outputJson, inputJson);
+
+    // qty target is string, Qty source is number → must cast
+    // qty target is string, Qty source is number → must cast with "" +
+    expect(t).toMatch(/"qty":[\s\S]*"" \+[\s\S]*Qty/);
   });
 });

--- a/src/utils/scribanGenerator.ts
+++ b/src/utils/scribanGenerator.ts
@@ -483,7 +483,9 @@ function renderRootArrayMapping(
   lines.push('{');
   for (const m of am.mappings) {
     if (!m.target.trim()) continue;
-    const targetType = typeMap?.[`${itemPrefix}.${m.target}`];
+    // typeMap is built from the root-array output JSON, whose keys are bare field
+    // names (no prefix), so look up by m.target directly.
+    const targetType = typeMap?.[m.target];
     const sourceType = m.source ? sourceTypeMap?.[`${itemPrefix}.${m.source}`] : undefined;
     lines.push(`  "${m.target}": ${renderFieldValue(m, alias, valuesSetMap, targetType, sourceType)},`);
   }
@@ -519,12 +521,15 @@ function renderArrayMapping(
   const source = outerAlias ? `${outerAlias}.${am.source}` : am.source;
   const filterExpr = renderFilter(alias, am.filter ?? undefined);
 
-  // Build the full item prefix for typeMap lookups, e.g. "labels[*]" or "orders[*].items[*]"
+  // Build the full item prefix for typeMap lookups, e.g. "labels[*]" or "orders[*].items[*]".
+  // Root-output AMs have target='' and no parent — they contribute no prefix segment so that
+  // their children resolve to "lines[*]" rather than "[*].lines[*]".
   function resolvePrefix(id: string): string {
     const m = allAMs.find((a) => a.id === id);
     if (!m) return '';
-    if (!m.parentArrayId) return `${m.target}[*]`;
-    return `${resolvePrefix(m.parentArrayId)}.${m.target}[*]`;
+    if (!m.parentArrayId) return m.target ? `${m.target}[*]` : '';
+    const parentPrefix = resolvePrefix(m.parentArrayId);
+    return parentPrefix ? `${parentPrefix}.${m.target}[*]` : `${m.target}[*]`;
   }
   const itemPrefix = resolvePrefix(am.id);
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
       "ESNext",
       "dom"
     ],
-    "types": ["vite/client"],
+    "types": ["vitest/globals"],
     "module": "esnext",
     "target": "ES6",
     "paths": {


### PR DESCRIPTION
- typeMap lookup in renderRootArrayMapping used itemPrefix ("items[*].total") but buildTypeMap on a root array output produces bare keys ("total") — fix to look up m.target directly
- resolvePrefix in renderArrayMapping prepended "[*]" from the root output AM's empty target, turning "lines[*]" into "[*].lines[*]" — fix to return "" when target is empty so child AMs resolve correctly
- Add type-casting test block (G) to scribanRootArray.test.ts covering both bugs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type casting behavior for root-array output mode, ensuring proper conversion between string and numeric types.
  * Corrected nested array type resolution to prevent incorrect path prefixing.

* **Tests**
  * Added comprehensive test coverage for type casting scenarios in root-array output, including float conversion, string casting, and nested array handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->