### PR TITLE
chore: add required GitHub Actions permissions

### DIFF
--- a/.github/workflows/bitween-ui-cicd-gateway.yml
+++ b/.github/workflows/bitween-ui-cicd-gateway.yml
@@ -17,9 +17,11 @@ permissions:
   contents: write
   packages: write
 
+  security-events: read
 jobs:
   build-publish-deploy:
-    if: ${{ (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch' }}
+    if: ${{ (github.event_name == 'push' && github.ref_name == 'main') || 
+      github.event_name == 'workflow_dispatch' }}
     uses: simplify9/.github/.github/workflows/reusable-service-cicd.yml@main
     with:
       major-version: '8'


### PR DESCRIPTION
Ensures every GitHub Actions workflow on `main` has:

```yaml
permissions:
  contents: write
  security-events: read
```

Existing unrelated permission entries are preserved.

Existing job-level permission overrides are also updated so they do not override and remove the required workflow permissions.

No triggers, jobs, steps, deployment environments, or push branch lists are intentionally changed.