### PR TITLE
Hide email/password login when Microsoft-only sign-in is enabled

### DIFF
--- a/src/components/Login/index.tsx
+++ b/src/components/Login/index.tsx
@@ -6,10 +6,12 @@ import SignInWithMsButton from "src/components/Login/SignInWithMsButton";
 import {ToastContainer} from "react-toastify";
 import {BsFillEyeFill, BsFillEyeSlashFill} from "react-icons/bs";
 import {useTypedSelector} from "src/state/ReduxSotre";
+import {useAppConfigQuery} from "src/client/apis/generalApi";
 
 
 const Login = () => {
     const theme = useTypedSelector(i => i.theme)
+    const config = useAppConfigQuery()
     const {login} = useAuthApi();
     const [username, setUsername] = useState("");
     const [password, setPassword] = useState("");
@@ -79,6 +81,7 @@ const Login = () => {
 
                         <div className="mt-8">
                             <form>
+                                {!config.data?.disableEmailPasswordLogin && <>
                                 <div>
                                     <label htmlFor="email"
                                            className="block mb-2 text-sm text-gray-600 dark:text-gray-200">Email
@@ -118,6 +121,7 @@ const Login = () => {
                                     </Button>
 
                                 </div>
+                                </>}
                                 <SignInWithMsButton/>
                                 {
                                     error && <div className={"text-center mt-3 text-red-500"}>

--- a/src/components/Settings/AddMemberModal.tsx
+++ b/src/components/Settings/AddMemberModal.tsx
@@ -5,6 +5,7 @@ import FormField from "src/components/common/forms/FormField";
 import TextEditor from "src/components/common/forms/TextEditor";
 import {apiClient} from "src/client";
 import {ChoiceEditor} from "src/components/common/forms/ChoiceEditor";
+import {useAppConfigQuery} from "src/client/apis/generalApi";
 
 function isValidEmail(email: string) {
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -16,6 +17,8 @@ type Props = {
 }
 const AddMemberModal: React.FC<Props> = ({onClose}) => {
 
+    const config = useAppConfigQuery()
+    const disablePassword = Boolean(config.data?.disableEmailPasswordLogin)
     const [state, setState] = useState<CreateAccountModel>({name: "", email: "", password: "", role: 10});
     const [errors, setErrors] = useState<string[]>([]);
     const onSubmit = async () => {
@@ -27,7 +30,7 @@ const AddMemberModal: React.FC<Props> = ({onClose}) => {
         if (state.name?.length < 3) {
             errors.push("Name must be longer than 3 characters")
         }
-        if (state.password?.length < 7) {
+        if (!disablePassword && state.password?.length < 7) {
             errors.push("Password must be longer than 8 characters")
         }
         if (errors.length > 0) {
@@ -36,7 +39,7 @@ const AddMemberModal: React.FC<Props> = ({onClose}) => {
         }
 
 
-        const res = await apiClient.createMember(state)
+        const res = await apiClient.createMember(disablePassword ? {...state, password: ""} : state)
         if (res.succeeded) {
             onClose()
         }
@@ -57,13 +60,13 @@ const AddMemberModal: React.FC<Props> = ({onClose}) => {
 
         </div>
 
-        <div className="  w-full mb-6 ">
+        {!disablePassword && <div className="  w-full mb-6 ">
 
             <FormField title="Password" className="grow">
                 <TextEditor type={"password"} value={state.password}
                             onChange={(e) => setState((s) => ({...s, password: e}))}/>
             </FormField>
-        </div>
+        </div>}
         <div className="  w-full mb-6 ">
             <FormField title="Role" className="grow">
                 <ChoiceEditor optionTitle={(e) => e.title} optionValue={(e) => e.id} options={RolesSelection}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -19,5 +19,6 @@ export type Config = {
     msalClientId: string | null,
     msalRedirectUri: string | null,
     msalTenantId: string | null,
+    disableEmailPasswordLogin: boolean,
     isRabbitMqManagementConfigured: boolean
 }


### PR DESCRIPTION
Login page shows only "Sign in with Microsoft" and the add-user form drops the password field when DisableEmailPasswordLogin is on.